### PR TITLE
cache PLY

### DIFF
--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -7,8 +7,16 @@ module.exports = {
 
     AFRAME = AFRAME || window.AFRAME;
     AFRAME = AFRAME.aframeCore || AFRAME;
-    if (!AFRAME.components['ply-model'])    AFRAME.registerComponent('ply-model',   this['ply-model']);
-    if (!AFRAME.components['three-model'])  AFRAME.registerComponent('three-model', this['three-model']);
+
+    if (!AFRAME.systems['ply-model']) {
+      AFRAME.registerSystem('ply-model', this['ply-model'].System);
+    }
+    if (!AFRAME.components['ply-model']) {
+      AFRAME.registerComponent('ply-model', this['ply-model'].Component);
+    }
+    if (!AFRAME.components['three-model']) {
+      AFRAME.registerComponent('three-model', this['three-model']);
+    }
 
     this._registered = true;
   }

--- a/src/loaders/ply-model.js
+++ b/src/loaders/ply-model.js
@@ -5,39 +5,75 @@
  */
 THREE.PLYLoader = require('../../lib/PLYLoader');
 
-module.exports = {
-  schema: {src: { type: 'src' }},
+/**
+ * Loads, caches, resolves geometries.
+ *
+ * @member cache - Promises that resolve geometries keyed by `src`.
+ */
+module.exports.System = {
+  init: function () {
+    this.cache = {};
+  },
+
+  /**
+   * @returns {Promise}
+   */
+  getOrLoadGeometry: function (src, skipCache) {
+    var cache = this.cache;
+    var cacheItem = cache[src];
+
+    if (!skipCache && cacheItem) {
+      return cacheItem;
+    }
+
+    cache[src] = new Promise(function (resolve) {
+      var loader = new THREE.PLYLoader();
+      loader.load(src, function (geometry) {
+        resolve(geometry);
+      });
+    });
+    return cache[src];
+  },
+};
+
+module.exports.Component = {
+  schema: {
+    skipCache: {type: 'boolean', default: false},
+    src: {type: 'src'}
+  },
 
   init: function () {
     this.model = null;
   },
 
   update: function () {
-    var loader,
-        data = this.data;
+    var data = this.data;
+    var el = this.el;
+    var loader;
 
     if (!data.src) {
       console.warn('[%s] `src` property is required.', this.name);
       return;
     }
 
-    this.remove();
-    loader = new THREE.PLYLoader();
-    loader.load(data.src, this.load.bind(this));
-  },
-
-  load: function (geometry) {
-    this.model = new THREE.Mesh(geometry, new THREE.MeshPhongMaterial({
-      color: 0xFFFFFF,
-      shading: THREE.FlatShading,
-      vertexColors: THREE.VertexColors,
-      shininess: 0
-    }));
-    this.el.setObject3D('mesh', this.model);
-    this.el.emit('model-loaded', {format: 'ply', model: this.model});
+    // Get geometry from system, create and set mesh.
+    this.system.getOrLoadGeometry(data.src, data.skipCache).then(function (geometry) {
+      var model = createModel(geometry);
+      el.setObject3D('mesh', model);
+      el.emit('model-loaded', {format: 'ply', model: model});
+    });
   },
 
   remove: function () {
-    if (this.model) this.el.removeObject3D('mesh');
+    if (this.model) { this.el.removeObject3D('mesh'); }
   }
 };
+
+function createModel (geometry) {
+  return new THREE.Mesh(geometry, new THREE.MeshPhongMaterial({
+    color: 0xFFFFFF,
+    shading: THREE.FlatShading,
+    vertexColors: THREE.VertexColors,
+    shininess: 0
+  }));
+}


### PR DESCRIPTION
Makes it so it doesn't request duplicate models twice. Was using a 6MB three times, this makes it load much faster.

Makes me think we should have a single loader system and component that handles all of this, and we create a `registerLoader` API, and then we have a repo of wrapping all three.js loaders.
