### PR TITLE
Add detection to load skeletal animation correctly.

### DIFF
--- a/src/loaders/three-model.js
+++ b/src/loaders/three-model.js
@@ -40,13 +40,20 @@ module.exports = {
         loader.load(data.src, this.load.bind(this));
       } else if (data.loader === 'json') {
         loader = new THREE.JSONLoader();
-        loader.load(data.src, function (geometry /*, materials */) {
-          var mesh = new THREE.Mesh(geometry, new THREE.MeshLambertMaterial({
-            vertexColors: THREE.FaceColors,
-            morphTargets: !!(geometry.morphTargets || []).length,
-            morphNormals: !!(geometry.morphNormals || []).length,
-            skinning:     !!(geometry.skinIndices || []).length
-          }));
+        loader.load(data.src, function (geometry, materials) {
+
+          // Attempt to automatically detect common material options.
+          materials.forEach(function (mat) {
+            mat.vertexColors = (geometry.faces[0] || {}).color ? THREE.FaceColors : THREE.NoColors;
+            mat.skinning = !!(geometry.bones || []).length;
+            mat.morphTargets = !!(geometry.morphTargets || []).length;
+            mat.morphNormals = !!(geometry.morphNormals || []).length;
+          });
+
+          var mesh = (geometry.bones || []).length
+            ? new THREE.SkinnedMesh(geometry, new THREE.MultiMaterial(materials))
+            : new THREE.Mesh(geometry, new THREE.MultiMaterial(materials));
+
           this.load(mesh);
         }.bind(this));
       } else {


### PR DESCRIPTION
Changes:
- Create Mesh or SkinnedMesh as needed from JsonLoader response.
- Attempt to infer required settings for the materials.
- Fixes #86.

@msj121 @fuleinist Does this work as expected? It is based on #89 and #86, but I was worried about using `materials[0] instanceof THREE.MeshLambertMaterial` to make assumptions about whether animation is skeletal or morphtarget-based. I think models could even contain both kinds of animation.
