### PR TITLE
[sphere-collider] ignore entities without getObject3D (e.g. a-assets)

### DIFF
--- a/src/misc/sphere-collider.js
+++ b/src/misc/sphere-collider.js
@@ -68,10 +68,11 @@ module.exports = {
 
       // AABB collision detection
       function intersect (el) {
-        var radius,
-            mesh = el.getObject3D('mesh');
+        var radius, mesh;
+        if ( !el.getObject3D ) { return; }
+        mesh = el.getObject3D('mesh');
 
-        if (!mesh) return;
+        if (!mesh || !mesh.geometry) return;
 
         mesh.getWorldPosition(meshPosition);
         mesh.geometry.computeBoundingSphere();

--- a/src/misc/sphere-collider.js
+++ b/src/misc/sphere-collider.js
@@ -50,7 +50,6 @@ module.exports = {
       if (!mesh) { return; }
 
       position.copy(el.object3D.getWorldPosition());
-      mesh.getWorldPosition(position);
 
       // Update collisions.
       this.els.forEach(intersect);
@@ -70,7 +69,7 @@ module.exports = {
       // AABB collision detection
       function intersect (el) {
         var radius, mesh;
-        if ( !el.getObject3D ) { return; }
+        if ( !el.isEntity ) { return; }
         mesh = el.getObject3D('mesh');
 
         if (!mesh || !mesh.geometry) return;

--- a/src/misc/sphere-collider.js
+++ b/src/misc/sphere-collider.js
@@ -50,6 +50,7 @@ module.exports = {
       if (!mesh) { return; }
 
       position.copy(el.object3D.getWorldPosition());
+      mesh.getWorldPosition(position);
 
       // Update collisions.
       this.els.forEach(intersect);


### PR DESCRIPTION
If sphere-collider used without objects (the default) will crash on entities in the scene that don't have getObject3D (e.g. 'a-assets')