### PR TITLE
Include scale in sphere-collider radius calculations

### DIFF
--- a/src/misc/sphere-collider.js
+++ b/src/misc/sphere-collider.js
@@ -68,18 +68,22 @@ module.exports = {
   tick: (function () {
     var position = new THREE.Vector3(),
         meshPosition = new THREE.Vector3(),
+        meshScale = new THREE.Vector3(),
+        colliderScale = new THREE.Vector3(),
         distanceMap = new Map();
     return function () {
       var el = this.el,
           data = this.data,
           mesh = el.getObject3D('mesh'),
+          colliderRadius,
           collisions = [];
 
       if (!mesh) { return; }
 
       distanceMap.clear();
       position.copy(el.object3D.getWorldPosition());
-
+      el.object3D.getWorldScale(colliderScale);
+      colliderRadius = data.radius * scaleFactor(colliderScale);
       // Update collision list.
       this.els.forEach(intersect);
 
@@ -105,7 +109,7 @@ module.exports = {
 
       // Bounding sphere collision detection
       function intersect (el) {
-        var radius, mesh, distance;
+        var radius, mesh, distance, scale;
 
         if (!el.isEntity) { return; }
 
@@ -117,10 +121,15 @@ module.exports = {
         mesh.geometry.computeBoundingSphere();
         radius = mesh.geometry.boundingSphere.radius;
         distance = position.distanceTo(meshPosition);
-        if (distance < radius + data.radius) {
+        scale = scaleFactor(mesh.getWorldScale(meshScale));
+        if (distance < radius * scale + colliderRadius) {
           collisions.push(el);
           distanceMap.set(el, distance);
         }
+      }
+      // use max of scale factors to maintain bounding sphere collision
+      function scaleFactor (scaleVec) {
+        return Math.max.apply(null, Object.values(scaleVec));
       }
     };
   })(),

--- a/src/misc/sphere-collider.js
+++ b/src/misc/sphere-collider.js
@@ -129,7 +129,7 @@ module.exports = {
       }
       // use max of scale factors to maintain bounding sphere collision
       function scaleFactor (scaleVec) {
-        return Math.max.apply(null, Object.values(scaleVec));
+        return Math.max.apply(null, scaleVec.toArray());
       }
     };
   })(),

--- a/tests/misc/sphere-collider.test.js
+++ b/tests/misc/sphere-collider.test.js
@@ -45,5 +45,25 @@ suite('sphere-collider', function () {
       collider.tick();
       expect(collidee.is(collider.data.state)).to.be.false;
     });
+    test('collision radius accounts for collidee scale', function () {
+      // Obj3d needs forced update to pickup A-Frame attrs in test context
+      collidee.object3D.updateMatrixWorld(true);
+      collider.tick();
+      expect(collidee.is(collider.data.state)).to.be.false;
+      collidee.setAttribute('scale', '10 10  10');
+      collidee.object3D.updateMatrixWorld(true);
+      collider.tick();
+      expect(collidee.is(collider.data.state)).to.be.true;
+    });
+    test('collision radius accounts for collider scale', function () {
+      // Obj3d needs forced update to pickup A-Frame attrs in test context
+      collidee.object3D.updateMatrixWorld(true);
+      collider.tick();
+      expect(collidee.is(collider.data.state)).to.be.false;
+      collider.el.setAttribute('scale', '160 1 1');
+      collider.el.object3D.updateMatrixWorld(true);
+      collider.tick();
+      expect(collidee.is(collider.data.state)).to.be.true;
+    });
   });
 });

--- a/tests/misc/sphere-collider.test.js
+++ b/tests/misc/sphere-collider.test.js
@@ -1,3 +1,4 @@
+/* global suite, setup, test, expect */
 var entityFactory = require('../helpers').entityFactory;
 
 suite('sphere-collider', function () {
@@ -28,7 +29,7 @@ suite('sphere-collider', function () {
       process.nextTick(function () {
         expect(collider.el.components['sphere-collider']).to.not.be.ok;
         done();
-      })
+      });
     });
   });
 
@@ -44,5 +45,5 @@ suite('sphere-collider', function () {
       collider.tick();
       expect(collidee.is(collider.data.state)).to.be.false;
     });
-  }); 
+  });
 });


### PR DESCRIPTION
This allows sphere-collider to provide bounding sphere collision calculations that are synced with changes to scale in the AFRAME attributes or Object3D of entities by multiplying the collider and collidee radii by their largest world-scale factor when making distance comparison. 

I considered taking the collider entity radius scale calculations outside of `tick()` for efficiency and making updates only when needed by listening for "componentchanged" on the entity, but this wouldn't catch changes to scale on parent entities or changes made directly via the THREE.js api. 