### PR TITLE
Added "mesh-smooth" component to "misc". 

### DIFF
--- a/src/misc/README.md
+++ b/src/misc/README.md
@@ -5,6 +5,7 @@ Various other components.
 - **checkpoint**: Target for [checkpoint-controls](/src/controls/checkpoint-controls.js).
 - **grab**: When used on one or both hands, lets the player pick up objects with `vive-controls`. Requires `sphere-collider`.
 - **jump-ability**: Allows player to jump using keyboard or gamepad, when physics is enabled. *Not VR-friendly*.
+- **mesh-smooth**: Apply to models that looks "blocky", to have Three.js compute vertex normals on the fly for a "smooter" look.
 - **sphere-collider**: Detects collisions with specified objects. Required for `grab`.
 - **toggle-velocity**: Animates an object back and forth between two points, at a constant velocity.
-- **cube-env-map**: Applies a CubeTexture as the envMap of an entity, without otherwise modifying the preset materials. Usage: `cube-env-map="path: assets/folder/; extension: jpg;"`. Assumes naming scheme: negx, posx, ... 
+- **cube-env-map**: Applies a CubeTexture as the envMap of an entity, without otherwise modifying the preset materials. Usage: `cube-env-map="path: assets/folder/; extension: jpg;"`. Assumes naming scheme: negx, posx, ...

--- a/src/misc/index.js
+++ b/src/misc/index.js
@@ -6,6 +6,7 @@ module.exports = {
   'grab':            require('./grab'),
   'jump-ability':    require('./jump-ability'),
   'kinematic-body':  require('./kinematic-body'),
+  'mesh-smooth':     require('./mesh-smooth'),
   'sphere-collider': require('./sphere-collider'),
   'toggle-velocity': require('./toggle-velocity'),
 
@@ -20,6 +21,7 @@ module.exports = {
     if (!AFRAME.components['grab'])            AFRAME.registerComponent('grab',            this['grab']);
     if (!AFRAME.components['jump-ability'])    AFRAME.registerComponent('jump-ability',    this['jump-ability']);
     if (!AFRAME.components['kinematic-body'])  AFRAME.registerComponent('kinematic-body',  this['kinematic-body']);
+    if (!AFRAME.components['mesh-smooth'])     AFRAME.registerComponent('mesh-smooth',     this['mesh-smooth']);
     if (!AFRAME.components['sphere-collider']) AFRAME.registerComponent('sphere-collider', this['sphere-collider']);
     if (!AFRAME.components['toggle-velocity']) AFRAME.registerComponent('toggle-velocity', this['toggle-velocity']);
 

--- a/src/misc/mesh-smooth.js
+++ b/src/misc/mesh-smooth.js
@@ -1,0 +1,13 @@
+/**
+ * Apply this component to models that looks "blocky", to have Three.js compute
+ * vertex normals on the fly for a "smooter" look.
+ */
+module.exports = {
+  init: function () {
+    this.el.addEventListener('model-loaded', function (e) {
+      e.detail.model.traverse(function (node) {
+        if (node.isMesh) node.geometry.computeVertexNormals();
+      });
+    })
+  }
+}


### PR DESCRIPTION
Helps to give some models a "smoother" look by having Three.js calculate the vertex normals.

As per my own experiments, it works great with json-models, but have no effect on obj-models. Haven't tested with collada or gltf .