### PR TITLE
sphere-collider: add 'lost' event emission when collisions end

### DIFF
--- a/src/misc/sphere-collider.js
+++ b/src/misc/sphere-collider.js
@@ -25,6 +25,7 @@ module.exports = {
     this.collisions = [];
 
     this.handleHit = this.handleHit.bind(this);
+    this.handleHitEnd = this.handleHitEnd.bind(this);
   },
 
   remove: function () {
@@ -100,9 +101,7 @@ module.exports = {
       // Remove collision state from other elements.
       this.collisions.filter(function (el) {
         return !distanceMap.has(el);
-      }).forEach(function removeState (el) {
-        el.removeState(data.state);
-      });
+      }).forEach(this.handleHitEnd);
 
       // Store new collisions
       this.collisions = collisions;
@@ -142,5 +141,10 @@ module.exports = {
     targetEl.emit('hit');
     targetEl.addState(this.data.state);
     this.el.emit('hit', {el: targetEl});
+  },
+  handleHitEnd: function (targetEl) {
+    targetEl.emit('hitend');
+    targetEl.removeState(this.data.state);
+    this.el.emit('hitend', {el: targetEl});
   }
 };

--- a/tests/misc/sphere-collider.test.js
+++ b/tests/misc/sphere-collider.test.js
@@ -21,7 +21,6 @@ suite('sphere-collider', function () {
 
   suite('lifecycle', function () {
     test('attaches', function () {
-      console.log(this.el.components);
       expect(collider).to.be.ok;
     });
     test('detaches', function (done) {
@@ -64,6 +63,24 @@ suite('sphere-collider', function () {
       collider.el.object3D.updateMatrixWorld(true);
       collider.tick();
       expect(collidee.is(collider.data.state)).to.be.true;
+    });
+    test('hit and hitend event emission', function () {
+      var hitSpy = this.sinon.spy(),
+          hitEndSpy = this.sinon.spy(),
+          targetHitSpy = this.sinon.spy(),
+          targetHitEndSpy = this.sinon.spy();
+      collider.el.addEventListener('hit', hitSpy);
+      collider.el.addEventListener('hitend', hitEndSpy);
+      collidee.addEventListener('hit', targetHitSpy);
+      collidee.addEventListener('hitend', targetHitEndSpy);
+      collidee.setAttribute('position', collider.el.getAttribute('position'));
+      collider.tick();
+      expect(hitSpy.calledWithMatch({detail: {el: collidee}})).to.be.true;
+      expect(targetHitSpy.called).to.be.true;
+      collider.el.setAttribute('position', '5 5 5');
+      collider.tick();
+      expect(hitEndSpy.calledWithMatch({detail: {el: collidee}})).to.be.true;
+      expect(targetHitEndSpy.called).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Currently, new collisions can be detected via the `'hit'` event, but the end of a collision can only be tracked by listening for `'stateremoved'`. Adding a corresponding `'lost'` event would provide two advantages:

1. The ability to distinguish which collider has ended its collision with an entity in scenes with multiple `sphere-collider`s (e.g. two hand controllers). At present, when both hands are hovering an entity and one leaves, there is no way to tell which. 
2. Interface consistent with `raycaster`. The analogous component for detecting collisions for gaze and laser-pointers uses the start/end event pattern. As I expand `super-hands` to support more modes of control, a common interface would be advantageous. 
