### PR TITLE
[universal-controls] Support constraint to nav mesh.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6493,9 +6493,9 @@
       }
     },
     "three-pathfinding": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/three-pathfinding/-/three-pathfinding-0.2.3.tgz",
-      "integrity": "sha512-E5RGGtDk+xmsSk1A8Cbm6SxkTpRQ6/GU0bPL5XugK4jdx4MJCWXAlPZYC9SbXeaqG0aXultweOtDzIAgKL1ynw=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/three-pathfinding/-/three-pathfinding-0.4.0.tgz",
+      "integrity": "sha512-rgkpFgmOzBurJVn+h34p5Us3dfjPlh48PCPtEA4z70gLkJEHcc/PlgbgdgBJ1HLEidNKlDCsD5GZlO4vSmkXTg=="
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "aframe": ">=0.5.0"
   },
   "dependencies": {
-    "three-pathfinding": "^0.2.2"
+    "three-pathfinding": "^0.4.0"
   },
   "devDependencies": {
     "aframe": ">=0.5.0",

--- a/src/controls/checkpoint-controls.js
+++ b/src/controls/checkpoint-controls.js
@@ -11,6 +11,8 @@ module.exports = AFRAME.registerComponent('checkpoint-controls', {
     this.active = true;
     this.checkpoint = null;
 
+    this.isNavMeshConstrained = false;
+
     this.offset = new THREE.Vector3();
     this.position = new THREE.Vector3();
     this.targetPosition = new THREE.Vector3();

--- a/src/controls/hmd-controls.js
+++ b/src/controls/hmd-controls.js
@@ -9,6 +9,7 @@ module.exports = AFRAME.registerComponent('hmd-controls', {
 
   init: function () {
     this.isPositionCalibrated = false;
+    this.isNavMeshConstrained = false;
     this.dolly = new THREE.Object3D();
     this.hmdEuler = new THREE.Euler();
     this.previousHMDPosition = new THREE.Vector3();

--- a/src/pathfinding/index.js
+++ b/src/pathfinding/index.js
@@ -1,3 +1,3 @@
 require('./nav-mesh');
-require('./nav-controller');
+require('./nav-agent');
 require('./system');

--- a/src/pathfinding/system.js
+++ b/src/pathfinding/system.js
@@ -1,4 +1,6 @@
-var Path = require('three-pathfinding');
+const Path = require('three-pathfinding');
+
+const ZONE = 'level';
 
 /**
  * nav
@@ -8,8 +10,8 @@ var Path = require('three-pathfinding');
 module.exports = AFRAME.registerSystem('nav', {
   init: function () {
     this.navMesh = null;
-    this.nodes = null;
-    this.controllers = new Set();
+    this.zone = null;
+    this.agents = new Set();
   },
 
   /**
@@ -20,8 +22,8 @@ module.exports = AFRAME.registerSystem('nav', {
       ? new THREE.Geometry().fromBufferGeometry(mesh.geometry)
       : mesh.geometry;
     this.navMesh = new THREE.Mesh(geometry);
-    this.nodes = Path.buildNodes(this.navMesh.geometry);
-    Path.setZoneData('level', this.nodes);
+    this.zone = Path.buildNodes(this.navMesh.geometry);
+    Path.setZoneData(ZONE, this.zone);
   },
 
   /**
@@ -32,28 +34,60 @@ module.exports = AFRAME.registerSystem('nav', {
   },
 
   /**
-   * @param {NavController} ctrl
+   * @param {NavAgent} ctrl
    */
-  addController: function (ctrl) {
-    this.controllers.add(ctrl);
+  addAgent: function (ctrl) {
+    this.agents.add(ctrl);
   },
 
   /**
-   * @param {NavController} ctrl
+   * @param {NavAgent} ctrl
    */
-  removeController: function (ctrl) {
-    this.controllers.remove(ctrl);
+  removeAgent: function (ctrl) {
+    this.agents.remove(ctrl);
   },
 
   /**
-   * @param  {NavController} ctrl
-   * @param  {THREE.Vector3} target
+   * @param  {THREE.Vector3} start
+   * @param  {THREE.Vector3} end
+   * @param  {Path.Group} group
    * @return {Array<THREE.Vector3>}
    */
-  getPath: function (ctrl, target) {
-    const start = ctrl.el.object3D.position;
-    // TODO(donmccurdy): Current group should be cached.
-    const group = Path.getGroup('level', start);
-    return Path.findPath(start, target, 'level', group);
+  getPath: function (start, end, group) {
+    return Path.findPath(start, end, ZONE, group);
+  },
+
+  /**
+   * @param {THREE.Vector3} position
+   * @return {Path.Group}
+   */
+  getGroup: function (position) {
+    return Path.getGroup(ZONE, position);
+  },
+
+  /**
+   * @param  {THREE.Vector3} position
+   * @param  {Path.Group} group
+   * @return {Path.Node}
+   */
+  getNode: function (position, group) {
+    return Path.getClosestNode(position, ZONE, group, true);
+  },
+
+  /**
+   * @param  {THREE.Vector3} start Starting position.
+   * @param  {THREE.Vector3} end Desired ending position.
+   * @param  {Path.Group} group
+   * @param  {Path.Node} node
+   * @param  {THREE.Vector3} endTarget (Output) Adjusted step end position.
+   * @return {Path.Node} Current node, after step is taken.
+   */
+  clampStep: function (start, end, group, node, endTarget) {
+    if (!this.navMesh || !node) {
+      endTarget.copy(end);
+      return this.navMesh ? Path.getNode(ZONE, group) : null;
+    }
+    return Path.clampStep(start, end, node, ZONE, group, endTarget);
   }
 });
+


### PR DESCRIPTION
TODO:

- [x] Move the `clampToNavMesh()` method into three-pathfinding.
- [x] Feels pretty janky in corners.
- [x] Make sure constraints are ignored for HMD-based and checkpoint-based positioning.

Fixes #186, fixes #161.