### PR TITLE
kinematic-body: check contact equation is enabled before applying force

### DIFF
--- a/src/misc/kinematic-body.js
+++ b/src/misc/kinematic-body.js
@@ -105,7 +105,9 @@ module.exports = {
 
       for (var i = 0, contact; (contact = this.system.world.contacts[i]); i++) {
         // 1. Find any collisions involving this element. Get the contact
-        // normal, and make sure it's oriented _out_ of the other object.
+        // normal, and make sure it's oriented _out_ of the other object and
+        // enabled (body.collisionReponse is true for both bodies)
+        if (!contact.enabled) { continue; }
         if (body.id === contact.bi.id) {
           contact.ni.negate(currentSurfaceNormal);
         } else if (body.id === contact.bj.id) {


### PR DESCRIPTION
This allows the use of `body.collisionReponse` (`aframe-physics-extras` `collision-filter.collisionForces`) to have collisions which are detectable but do not cause a physical response (e.g. to trigger an action upon entering a zone). 