### PR TITLE
Cube env map multi material and reflectivity support

### DIFF
--- a/src/misc/cube-env-map.js
+++ b/src/misc/cube-env-map.js
@@ -7,7 +7,8 @@ module.exports = AFRAME.registerComponent('cube-env-map', {
     path: {default: ''},
     extension: {default: 'jpg'},
     format: {default: 'RGBFormat'},
-    enableBackground: {default: false}
+    enableBackground: {default: false},
+    reflectivity: {default: 1}
   },
 
   init: function () {
@@ -40,6 +41,7 @@ module.exports = AFRAME.registerComponent('cube-env-map', {
       materials.forEach(material => {
         if (material && 'envMap' in material) {
           material.envMap = envMap;
+          material.reflectivity = this.data.reflectivity;
           material.needsUpdate = true;
         }
       });

--- a/src/misc/cube-env-map.js
+++ b/src/misc/cube-env-map.js
@@ -34,11 +34,27 @@ module.exports = AFRAME.registerComponent('cube-env-map', {
 
     if (!mesh) return;
 
-    mesh.traverse(function (node) {
-      if (node.material && 'envMap' in node.material) {
-        node.material.envMap = envMap;
-        node.material.needsUpdate = true;
-      }
+    mesh.traverse(node => {
+      const materials = this.ensureMaterialArray(node.material)
+
+      materials.forEach(material => {
+        if (material && 'envMap' in material) {
+          material.envMap = envMap;
+          material.needsUpdate = true;
+        }
+      });
     });
+  },
+
+  ensureMaterialArray: function (material) {
+    if(!material) {
+      return []
+    } else if(Array.isArray(material)) {
+      return material
+    } else if(material.materials) {
+      return material.materials
+    } else {
+      return [material]
+    }
   }
 });


### PR DESCRIPTION
This PR adds two things to the cube-env-map component:

1) Support for meshes with multiple materials (the cube map is applied to all of them)

2) Setting to specify the reflectivity of the of the env map across all materials it is applied to.