### PR TITLE
Added materials property to cube-env-map

### DIFF
--- a/src/misc/README.md
+++ b/src/misc/README.md
@@ -8,4 +8,4 @@ Various other components.
 - **mesh-smooth**: Apply to models that looks "blocky", to have Three.js compute vertex normals on the fly for a "smoother" look.
 - **sphere-collider**: Detects collisions with specified objects. Required for `grab`.
 - **toggle-velocity**: Animates an object back and forth between two points, at a constant velocity.
-- **cube-env-map**: Applies a CubeTexture as the envMap of an entity, without otherwise modifying the preset materials. Usage: `cube-env-map="path: assets/folder/; extension: jpg;"`. Assumes naming scheme: negx, posx, ...
+- **cube-env-map**: Applies a CubeTexture as the envMap of an entity, without otherwise modifying the preset materials. Usage: `cube-env-map="path: assets/folder/; extension: jpg; reflectivity: 0.5; materials: front, 0.2, back, 0.8;"`. Assumes naming scheme: negx, posx, ... Materials is an optional array of named materials to apply the map to (default is all); each name can optionally by followed by a specific reflectivity for that material.

--- a/src/misc/cube-env-map.js
+++ b/src/misc/cube-env-map.js
@@ -8,7 +8,8 @@ module.exports = AFRAME.registerComponent('cube-env-map', {
     extension: {default: 'jpg'},
     format: {default: 'RGBFormat'},
     enableBackground: {default: false},
-    reflectivity: {default: 1}
+    reflectivity: {default: 1},
+    materials: {default: []}
   },
 
   init: function () {
@@ -40,9 +41,12 @@ module.exports = AFRAME.registerComponent('cube-env-map', {
 
       materials.forEach(material => {
         if (material && 'envMap' in material) {
-          material.envMap = envMap;
-          material.reflectivity = this.data.reflectivity;
-          material.needsUpdate = true;
+          const reflectivity = this.getMaterialReflectivity(material);
+          if(reflectivity) {
+            material.envMap = envMap;
+            material.reflectivity = reflectivity;
+            material.needsUpdate = true;  
+          }
         }
       });
     });
@@ -57,6 +61,24 @@ module.exports = AFRAME.registerComponent('cube-env-map', {
       return material.materials
     } else {
       return [material]
+    }
+  },
+
+  getMaterialReflectivity: function (material) {
+    if(this.data.materials.length === 0) {
+      return this.data.reflectivity;
+    }
+
+    const index = this.data.materials.indexOf(material.name)
+    if(index === -1) {
+      return null;
+    }
+
+    const specificReflectivity = parseFloat(this.data.materials[index + 1]);
+    if(isNaN(specificReflectivity)) {
+      return this.data.reflectivity;
+    } else {
+      return specificReflectivity;
     }
   }
 });

--- a/src/misc/cube-env-map.js
+++ b/src/misc/cube-env-map.js
@@ -3,6 +3,7 @@
  * properties.
  */
 module.exports = AFRAME.registerComponent('cube-env-map', {
+  multiple: true,
   schema: {
     path: {default: ''},
     extension: {default: 'jpg'},
@@ -40,13 +41,13 @@ module.exports = AFRAME.registerComponent('cube-env-map', {
       const materials = this.ensureMaterialArray(node.material)
 
       materials.forEach(material => {
-        if (material && 'envMap' in material) {
-          const reflectivity = this.getMaterialReflectivity(material);
-          if(reflectivity) {
-            material.envMap = envMap;
-            material.reflectivity = reflectivity;
-            material.needsUpdate = true;  
-          }
+        if (
+          material && 'envMap' in material && 
+          (!this.data.materials.length || this.data.materials.indexOf(material.name) > -1)
+        ) {
+          material.envMap = envMap;
+          material.reflectivity = this.data.reflectivity;
+          material.needsUpdate = true;  
         }
       });
     });
@@ -61,24 +62,6 @@ module.exports = AFRAME.registerComponent('cube-env-map', {
       return material.materials
     } else {
       return [material]
-    }
-  },
-
-  getMaterialReflectivity: function (material) {
-    if(this.data.materials.length === 0) {
-      return this.data.reflectivity;
-    }
-
-    const index = this.data.materials.indexOf(material.name)
-    if(index === -1) {
-      return null;
-    }
-
-    const specificReflectivity = parseFloat(this.data.materials[index + 1]);
-    if(isNaN(specificReflectivity)) {
-      return this.data.reflectivity;
-    } else {
-      return specificReflectivity;
     }
   }
 });


### PR DESCRIPTION
The materials property allows the user to specify that the env map should only be applied to certain named materials. Optionally, each named material can be followed by a number indicating a specific reflectivity for that material.