### PR TITLE
Remove babelify from runtime bundling config

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,17 +65,5 @@
     "vr",
     "webgl",
     "webvr"
-  ],
-  "browserify": {
-    "transform": [
-      [
-        "babelify",
-        {
-          "presets": [
-            "env"
-          ]
-        }
-      ]
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
Attempting to include aframe-extras in a bundle via browserify's `require` statement generates the following error:

```
Error: Cannot find module 'babelify' from [aframe extras folder in node_modules]
```

The `browserify.transform` field is invoked even when the package is bundled as a dependency ([browserify handbook](https://github.com/browserify/browserify-handbook#browserifytransform-field)), but `babelify` is not specified in the runtime dependencies.

It looks like all of your distribution scripts specify the babelify transform directly, so I don't think this will impact the development workflow. 