### PR TITLE
Added clamp option in the animation-mixer component

### DIFF
--- a/src/loaders/animation-mixer.js
+++ b/src/loaders/animation-mixer.js
@@ -15,6 +15,7 @@ module.exports = AFRAME.registerComponent('animation-mixer', {
   schema: {
     clip:  {default: '*'},
     duration: {default: 0},
+    clamp: {default: false, type: 'boolean'},
     crossFadeDuration: {default: 0},
     loop: {default: 'repeat', oneOf: Object.keys(LoopMode)},
     repetitions: {default: Infinity, min: 0}
@@ -91,6 +92,7 @@ module.exports = AFRAME.registerComponent('animation-mixer', {
       if (clip.name.match(re)) {
         const action = this.mixer.clipAction(clip, model);
         action.enabled = true;
+        action.clampWhenFinished = data.clamp;
         if (data.duration) action.setDuration(data.duration);
         action
           .setLoop(LoopMode[data.loop], data.repetitions)

--- a/src/loaders/animation-mixer.js
+++ b/src/loaders/animation-mixer.js
@@ -15,7 +15,7 @@ module.exports = AFRAME.registerComponent('animation-mixer', {
   schema: {
     clip:  {default: '*'},
     duration: {default: 0},
-    clamp: {default: false, type: 'boolean'},
+    clampWhenFinished: {default: false, type: 'boolean'},
     crossFadeDuration: {default: 0},
     loop: {default: 'repeat', oneOf: Object.keys(LoopMode)},
     repetitions: {default: Infinity, min: 0}
@@ -92,7 +92,7 @@ module.exports = AFRAME.registerComponent('animation-mixer', {
       if (clip.name.match(re)) {
         const action = this.mixer.clipAction(clip, model);
         action.enabled = true;
-        action.clampWhenFinished = data.clamp;
+        action.clampWhenFinished = data.clampWhenFinished;
         if (data.duration) action.setDuration(data.duration);
         action
           .setLoop(LoopMode[data.loop], data.repetitions)


### PR DESCRIPTION
When I tried animating gltf objects in a scene, the object would always reset its position to the starting frame of the animation when done. The "ClampWhenFinished" option was not built into the component, so I took the time to add a "clamp" option myself. I am sure other users will find this option useful.

https://threejs.org/docs/#api/animation/AnimationAction.clampWhenFinished