### PR TITLE
Swipe-based rather than touch-based movement for trackpad controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,9 +50,7 @@
       "requires": {
         "@tweenjs/tween.js": "^16.8.0",
         "browserify-css": "^0.8.2",
-        "debug": "github:ngokevin/debug#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a",
         "deep-assign": "^2.0.0",
-        "document-register-element": "github:dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90",
         "envify": "^3.4.1",
         "load-bmfont": "^1.2.3",
         "object-assign": "^4.0.1",
@@ -64,6 +62,14 @@
         "webvr-polyfill": "^0.9.40"
       },
       "dependencies": {
+        "debug": {
+          "version": "github:ngokevin/debug#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a",
+          "from": "github:ngokevin/debug#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a"
+        },
+        "document-register-element": {
+          "version": "github:dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90",
+          "from": "github:dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90"
+        },
         "envify": {
           "version": "3.4.1",
           "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
@@ -1104,6 +1110,15 @@
         "type-is": "~1.6.10"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
         "http-errors": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
@@ -1118,6 +1133,12 @@
           "version": "0.4.13",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
           "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         },
         "qs": {
@@ -1924,16 +1945,6 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
-    "cors": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
-      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
-      "dev": true,
-      "requires": {
-        "object-assign": "^4",
-        "vary": "^1"
-      }
-    },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
@@ -2045,11 +2056,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.1.0.tgz",
       "integrity": "sha512-ZQVKfRVlwRfD150ndzEK8M90ABT+Y/JQKs4Y7U4MXdpuoUkkrr4DwKbVux3YjylA5bUMUj0Nc3pMxPJX6N2QQQ==",
-      "dev": true
-    },
-    "debug": {
-      "version": "github:ngokevin/debug#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a",
-      "from": "github:ngokevin/debug#noTimestamp",
       "dev": true
     },
     "decamelize": {
@@ -2222,11 +2228,6 @@
         "miller-rabin": "^4.0.0",
         "randombytes": "^2.0.0"
       }
-    },
-    "document-register-element": {
-      "version": "github:dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90",
-      "from": "github:dmarcos/document-register-element#8ccc532b7",
-      "dev": true
     },
     "dom-serialize": {
       "version": "2.2.1",
@@ -2497,21 +2498,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
-    },
-    "event-stream": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-      "dev": true,
-      "requires": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
-      }
     },
     "eventemitter3": {
       "version": "1.2.0",
@@ -4383,12 +4369,6 @@
       "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
       "dev": true
     },
-    "is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-      "dev": true
-    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -4823,24 +4803,24 @@
       "dev": true,
       "requires": {
         "chokidar": "^1.6.0",
-        "colors": "latest",
+        "colors": "^1.3.2",
         "connect": "3.5.x",
-        "cors": "latest",
-        "event-stream": "latest",
+        "cors": "^2.8.4",
+        "event-stream": "^4.0.1",
         "faye-websocket": "0.11.x",
         "http-auth": "3.1.x",
         "morgan": "^1.6.1",
-        "object-assign": "latest",
-        "opn": "latest",
-        "proxy-middleware": "latest",
-        "send": "latest",
+        "object-assign": "^4.1.1",
+        "opn": "^5.4.0",
+        "proxy-middleware": "^0.15.0",
+        "send": "^0.16.2",
         "serve-index": "^1.7.2"
       },
       "dependencies": {
         "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
+          "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==",
           "dev": true
         },
         "connect": {
@@ -4853,6 +4833,48 @@
             "finalhandler": "0.5.1",
             "parseurl": "~1.3.1",
             "utils-merge": "1.0.0"
+          }
+        },
+        "cors": {
+          "version": "2.8.4",
+          "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+          "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4",
+            "vary": "^1"
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+              "dev": true
+            }
+          }
+        },
+        "event-stream": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+          "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+          "dev": true,
+          "requires": {
+            "duplexer": "^0.1.1",
+            "from": "^0.1.7",
+            "map-stream": "0.0.7",
+            "pause-stream": "^0.0.11",
+            "split": "^1.0.1",
+            "stream-combiner": "^0.2.2",
+            "through": "^2.3.8"
           }
         },
         "faye-websocket": {
@@ -4877,6 +4899,12 @@
             "unpipe": "~1.0.0"
           }
         },
+        "map-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+          "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
+          "dev": true
+        },
         "mime": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
@@ -4890,24 +4918,38 @@
           "dev": true
         },
         "opn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
-          "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
+          "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
           "dev": true,
           "requires": {
             "is-wsl": "^1.1.0"
+          },
+          "dependencies": {
+            "is-wsl": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+              "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+              "dev": true
+            }
           }
         },
+        "proxy-middleware": {
+          "version": "0.15.0",
+          "resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
+          "integrity": "sha1-o/3xvvtzD5UZZYcqwvYHTGFHelY=",
+          "dev": true
+        },
         "send": {
-          "version": "0.16.1",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
-          "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+          "version": "0.16.2",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+          "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "depd": "~1.1.1",
+            "depd": "~1.1.2",
             "destroy": "~1.0.4",
-            "encodeurl": "~1.0.1",
+            "encodeurl": "~1.0.2",
             "escape-html": "~1.0.3",
             "etag": "~1.8.1",
             "fresh": "0.5.2",
@@ -4916,7 +4958,7 @@
             "ms": "2.0.0",
             "on-finished": "~2.3.0",
             "range-parser": "~1.2.0",
-            "statuses": "~1.3.1"
+            "statuses": "~1.4.0"
           },
           "dependencies": {
             "debug": {
@@ -4927,7 +4969,44 @@
               "requires": {
                 "ms": "2.0.0"
               }
+            },
+            "depd": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+              "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+              "dev": true
+            },
+            "encodeurl": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+              "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+              "dev": true
+            },
+            "statuses": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+              "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+              "dev": true
             }
+          }
+        },
+        "split": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+          "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+          "dev": true,
+          "requires": {
+            "through": "2"
+          }
+        },
+        "stream-combiner": {
+          "version": "0.2.2",
+          "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+          "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+          "dev": true,
+          "requires": {
+            "duplexer": "~0.1.1",
+            "through": "~2.3.4"
           }
         },
         "utils-merge": {
@@ -5177,12 +5256,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true
-    },
-    "map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
     "md5": {
@@ -6060,12 +6133,6 @@
       "integrity": "sha1-YpUrAdBZsRW0MnY7fvRhuA9t9H0=",
       "dev": true
     },
-    "proxy-middleware": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
-      "integrity": "sha1-o/3xvvtzD5UZZYcqwvYHTGFHelY=",
-      "dev": true
-    },
     "public-encrypt": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
@@ -6535,6 +6602,17 @@
       "requires": {
         "debug": "^2.2.0",
         "minimatch": "^3.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "resumer": {
@@ -6922,6 +7000,23 @@
         "debug": "2.2.0",
         "isarray": "0.0.1",
         "json3": "3.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        }
       }
     },
     "source-map": {
@@ -6970,15 +7065,6 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
-    },
-    "split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-      "dev": true,
-      "requires": {
-        "through": "2"
-      }
     },
     "split2": {
       "version": "0.2.1",
@@ -7082,15 +7168,6 @@
             "safe-buffer": "~5.1.0"
           }
         }
-      }
-    },
-    "stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "dev": true,
-      "requires": {
-        "duplexer": "~0.1.1"
       }
     },
     "stream-combiner2": {
@@ -7468,6 +7545,23 @@
         "livereload-js": "^2.2.0",
         "parseurl": "~1.3.0",
         "qs": "~5.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        }
       }
     },
     "tmp": {

--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -80,14 +80,8 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
 
 
     if(this.startingAxisData.length > 0){
-      var movingLeft     = this.startingAxisData[0] > 0 && axis_data[0] < 0
-      var movingRight    = this.startingAxisData[0] < 0 && axis_data[0] > 0
-      var movingForward  = this.startingAxisData[1] > 0 && axis_data[1] < 0
-      var movingBackward = this.startingAxisData[1] < 0 && axis_data[1] > 0
-
       var velX = axis_data[0] < this.startingAxisData[0] ? -1 : 1
       var velZ = axis_data[1] < this.startingAxisData[1] ? 1 : -1
-
 
       var absChangeZ = Math.abs(this.startingAxisData[1] - axis_data[1])
       var absChangeX = Math.abs(this.startingAxisData[0] - axis_data[0])

--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -134,19 +134,19 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
       let velX = 0;
       let velZ = 0;
 
-      if(this.data.enableNegX && ( axisData[0] < this.startingAxisData[0] )) {
+      if(this.data.enableNegX == true && ( axisData[0] < this.startingAxisData[0] )) {
         velX = -1;
       }
 
-      if(this.data.enablePosX && ( axisData[0] > this.startingAxisData[0] )) {
+      if(this.data.enablePosX == true && ( axisData[0] > this.startingAxisData[0] )) {
         velX = 1;
       }
 
-      if(this.data.enableNegZ && ( axisData[1] > this.startingAxisData[1] )) {
+      if(this.data.enableNegZ == true && ( axisData[1] > this.startingAxisData[1] )) {
         velZ = -1;
       }
 
-      if(this.data.enableNegZ && ( axisData[1] < this.startingAxisData[1] )) {
+      if(this.data.enableNegZ == true && ( axisData[1] < this.startingAxisData[1] )) {
         velZ = 1;
       }
 
@@ -170,19 +170,19 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
     let velX = 0;
     let velZ = 0;
 
-    if(this.data.enableNegX && ( axisData[0] < 0 )) {
+    if(this.data.enableNegX == true && ( axisData[0] < 0 )) {
       velX = -1;
     }
 
-    if(this.data.enablePosX && ( axisData[0] > 0 )) {
+    if(this.data.enablePosX == true && ( axisData[0] > 0 )) {
       velX = 1;
     }
 
-    if(this.data.enableNegZ && ( axisData[1] > 0 )) {
+    if(this.data.enableNegZ == true && ( axisData[1] > 0 )) {
       velZ = -1;
     }
 
-    if(this.data.enableNegZ && ( axisData[1] < 0 )) {
+    if(this.data.enableNegZ == true && ( axisData[1] < 0 )) {
       velZ = 1;
     }
 

--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -61,7 +61,6 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
 
   onTouchStart: function (e) {
     this.startingAxisData = [];
-    this.canRecordAxis = true;
     e.preventDefault();
   },
 

--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -126,7 +126,6 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
       this.canRecordAxis = false;
       this.startingAxisData[0] = axisData[0];
       this.startingAxisData[1] = axisData[1];
-      this.isMoving = true;
     }
 
 
@@ -142,7 +141,7 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
         velX = 1;
       }
 
-      if(this.data.enableNegZ == true && ( axisData[1] > this.startingAxisData[1] )) {
+      if(this.data.enablePosZ == true && ( axisData[1] > this.startingAxisData[1] )) {
         velZ = -1;
       }
 
@@ -150,15 +149,17 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
         velZ = 1;
       }
 
-      const absChangeZ = Math.abs(this.startingAxisData[1] - axisData[1]);
-      const absChangeX = Math.abs(this.startingAxisData[0] - axisData[0]);
+      const absChangeZ  = Math.abs(this.startingAxisData[1] - axisData[1]);
+      const absChangeX  = Math.abs(this.startingAxisData[0] - axisData[0]);
 
       if(absChangeX > absChangeZ)  {
         this.zVel = 0;
         this.xVel = velX;
+        this.isMoving = true;
       }else{
         this.xVel = 0;
         this.zVel = velZ;
+        this.isMoving = true;
       }
 
     }
@@ -178,7 +179,7 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
       velX = 1;
     }
 
-    if(this.data.enableNegZ == true && ( axisData[1] > 0 )) {
+    if(this.data.enablePosZ == true && ( axisData[1] > 0 )) {
       velZ = -1;
     }
 

--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -4,7 +4,10 @@
 module.exports = AFRAME.registerComponent('trackpad-controls', {
   schema: {
     enabled: { default: true },
-    allowStrafe: { default: true },
+    enableNegX: { default: true },
+    enablePosX: { default: true },
+    enableNegZ: { default: true },
+    enablePosZ: { default: true },
     mode: { type: 'string', default: 'swipe', oneOf: ['swipe', 'touch', 'press'] }
 
   },
@@ -128,13 +131,29 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
 
 
     if(this.startingAxisData.length > 0){
-      const velX = axisData[0] < this.startingAxisData[0] ? -1 : 1;
-      const velZ = axisData[1] < this.startingAxisData[1] ? 1 : -1;
+      let velX = 0;
+      let velZ = 0;
+
+      if(this.data.enableNegX && ( axisData[0] < this.startingAxisData[0] )) {
+        velX = -1;
+      }
+
+      if(this.data.enablePosX && ( axisData[0] > this.startingAxisData[0] )) {
+        velX = 1;
+      }
+
+      if(this.data.enableNegZ && ( axisData[1] > this.startingAxisData[1] )) {
+        velZ = -1;
+      }
+
+      if(this.data.enableNegZ && ( axisData[1] < this.startingAxisData[1] )) {
+        velZ = 1;
+      }
 
       const absChangeZ = Math.abs(this.startingAxisData[1] - axisData[1]);
       const absChangeX = Math.abs(this.startingAxisData[0] - axisData[0]);
 
-      if((absChangeX > absChangeZ) && this.data.allowStrafe == true) {
+      if(absChangeX > absChangeZ)  {
         this.zVel = 0;
         this.xVel = velX;
       }else{
@@ -148,10 +167,26 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
   handleTouchAxis: function(e) {
     var axisData = e.detail.axis;
 
-    const velX = axisData[0] < 0 ? -1 : 1;
-    const velZ = axisData[1] < 0 ? 1 : -1;
+    let velX = 0;
+    let velZ = 0;
 
-    if(Math.abs(axisData[0]) > Math.abs(axisData[1]) && this.data.allowStrafe) {
+    if(this.data.enableNegX && ( axisData[0] < 0 )) {
+      velX = -1;
+    }
+
+    if(this.data.enablePosX && ( axisData[0] > 0 )) {
+      velX = 1;
+    }
+
+    if(this.data.enableNegZ && ( axisData[1] > 0 )) {
+      velZ = -1;
+    }
+
+    if(this.data.enableNegZ && ( axisData[1] < 0 )) {
+      velZ = 1;
+    }
+
+    if(Math.abs(axisData[0]) > Math.abs(axisData[1])) {
       this.zVel = 0;
       this.xVel = velX;
     }else{

--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -49,6 +49,7 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
 
   getVelocityDelta: function () {
     this.dVelocity.z = this.isMoving ? -this.zVel : 1;
+    this.dVelocity.x = this.isMoving ? this.xVel : 1;
     return this.dVelocity.clone();
   },
 
@@ -59,11 +60,13 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
   },
 
   onTouchStart: function (e) {
-    this.isMoving = true;
+    this.startingAxisData = [];
+    this.canRecordAxis = true;
     e.preventDefault();
   },
 
   onTouchEnd: function (e) {
+    this.startingAxisData = [];
     this.isMoving = false;
     e.preventDefault();
   },
@@ -71,14 +74,36 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
   onAxisMove: function(e){
     var axis_data = e.detail.axis;
 
-    if(axis_data[1] < 0){
-      this.zVel = 1;
+    if(this.startingAxisData.length === 0){
+      this.startingAxisData[0] = axis_data[0]
+      this.startingAxisData[1] = axis_data[1]
     }
 
-    if(axis_data[1] > 0){
-      this.zVel = -1;
-    }
 
+    if(this.startingAxisData.length > 0){
+      var movingLeft     = this.startingAxisData[0] > 0 && axis_data[0] < 0
+      var movingRight    = this.startingAxisData[0] < 0 && axis_data[0] > 0
+      var movingForward  = this.startingAxisData[1] > 0 && axis_data[1] < 0
+      var movingBackward = this.startingAxisData[1] < 0 && axis_data[1] > 0
+
+      var velX = axis_data[0] < this.startingAxisData[0] ? -1 : 1
+      var velZ = axis_data[1] < this.startingAxisData[1] ? 1 : -1
+
+
+      var absChangeZ = Math.abs(this.startingAxisData[1] - axis_data[1])
+      var absChangeX = Math.abs(this.startingAxisData[0] - axis_data[0])
+
+      if(absChangeZ > absChangeX) {
+        this.xVel = 0;
+        this.zVel = velZ;
+        this.isMoving = true;
+
+      }else{
+        this.zVel = 0;
+        this.xVel = velX
+        this.isMoving = true;
+      }
+    }
   }
-
 });
+

--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -60,6 +60,7 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
   },
 
   onTouchStart: function (e) {
+    this.canRecordAxis = true;
     this.startingAxisData = [];
     e.preventDefault();
   },
@@ -73,29 +74,30 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
   onAxisMove: function(e){
     var axis_data = e.detail.axis;
 
-    if(this.startingAxisData.length === 0){
-      this.startingAxisData[0] = axis_data[0]
-      this.startingAxisData[1] = axis_data[1]
+    if(this.startingAxisData.length === 0 && this.canRecordAxis){
+      this.canRecordAxis = false;
+      this.startingAxisData[0] = axis_data[0];
+      this.startingAxisData[1] = axis_data[1];
+      this.isMoving = true;
     }
 
 
     if(this.startingAxisData.length > 0){
-      var velX = axis_data[0] < this.startingAxisData[0] ? -1 : 1
-      var velZ = axis_data[1] < this.startingAxisData[1] ? 1 : -1
+      const velX = axis_data[0] < this.startingAxisData[0] ? -1 : 1;
+      const velZ = axis_data[1] < this.startingAxisData[1] ? 1 : -1;
 
-      var absChangeZ = Math.abs(this.startingAxisData[1] - axis_data[1])
-      var absChangeX = Math.abs(this.startingAxisData[0] - axis_data[0])
+      const absChangeZ = Math.abs(this.startingAxisData[1] - axis_data[1]);
+      const absChangeX = Math.abs(this.startingAxisData[0] - axis_data[0]);
 
       if(absChangeZ > absChangeX) {
         this.xVel = 0;
         this.zVel = velZ;
-        this.isMoving = true;
 
       }else{
         this.zVel = 0;
-        this.xVel = velX
-        this.isMoving = true;
+        this.xVel = velX;
       }
+
     }
   }
 });

--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -33,35 +33,35 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
   },
 
   addEventListeners: function () {
-    const sceneEl = this.el.sceneEl;
+    const targetEl = this.el;
 
-    sceneEl.addEventListener('axismove', this.onAxisMove);
+    targetEl.addEventListener('axismove', this.onAxisMove);
 
     if(this.data.mode == 'swipe' || this.data.mode == 'touch') {
-      sceneEl.addEventListener('trackpadtouchstart', this.onTouchStart);
-      sceneEl.addEventListener('trackpadtouchend', this.onTouchEnd);
+      targetEl.addEventListener('trackpadtouchstart', this.onTouchStart);
+      targetEl.addEventListener('trackpadtouchend', this.onTouchEnd);
     }
 
     if(this.data.mode == 'press') {
-      sceneEl.addEventListener('trackpaddown', this.onTouchStart);
-      sceneEl.addEventListener('trackpadup', this.onTouchEnd);
+      targetEl.addEventListener('trackpaddown', this.onTouchStart);
+      targetEl.addEventListener('trackpadup', this.onTouchEnd);
     }
 
   },
 
   removeEventListeners: function () {
-    const sceneEl = this.el.sceneEl;
+    const targetEl = this.el;
 
-    sceneEl.removeEventListener('axismove', this.onAxisMove);
+    targetEl.removeEventListener('axismove', this.onAxisMove);
 
     if(this.data.mode == 'swipe' || this.data.mode == 'touch') {
-      sceneEl.removeEventListener('trackpadtouchstart', this.onTouchStart);
-      sceneEl.removeEventListener('trackpadtouchend', this.onTouchEnd);
+      targetEl.removeEventListener('trackpadtouchstart', this.onTouchStart);
+      targetEl.removeEventListener('trackpadtouchend', this.onTouchEnd);
     }
 
     if(this.data.mode == 'press') {
-      sceneEl.removeEventListener('trackpaddown', this.onTouchStart);
-      sceneEl.removeEventListener('trackpadup', this.onTouchEnd);
+      targetEl.removeEventListener('trackpaddown', this.onTouchStart);
+      targetEl.removeEventListener('trackpadup', this.onTouchEnd);
     }
 
   },


### PR DESCRIPTION
The original version of trackpad-controls initiated player movement when the user touched the trackpad. After play-testing this behavior with a bunch of people, as well as observing how other games/experiences have handled free movement, it seems to make much more sense to have "swipe based" movement instead, for a couple of reasons:

Touch-based movement makes implementing side-to-side "strafing" difficult, if not impossible.
Touch-based movement renders the trackpad on the controller virtually useless for any activity other than movement.
This PR updates the component to use "swiping" to initiate movement. Swiping from the bottom to the top of the pad will propel the user forward. Swiping from top to bottom will move them back. Swiping side to side will move them in the corresponding direction as well, which is an added feature over the original version.