### PR TITLE
Solve speed issue on lower framerates #254

### DIFF
--- a/src/controls/movement-controls.js
+++ b/src/controls/movement-controls.js
@@ -202,10 +202,10 @@ module.exports = AFRAME.registerComponent('movement-controls', {
         const factor = dVelocity.length();
         if (data.fly) {
           velocity.copy(dVelocity);
-          velocity.multiplyScalar(this.data.speed * dt);
+          velocity.multiplyScalar(this.data.speed * 16.66667);
         } else {
           vector2.set(dVelocity.x, dVelocity.z);
-          vector2.setLength(factor * this.data.speed * dt);
+          vector2.setLength(factor * this.data.speed * 16.66667);
           velocity.x = vector2.x;
           velocity.z = vector2.y;
         }


### PR DESCRIPTION
Issue #254 

Velocity is now multiplied by a constant instead of dt (delta) because at tick() the velocity is again multiplied by dt. This makes the speed constant independently of the framerate (before on lower framerates the movement was faster). The constant is the delta at 60fps (16.66667).

This is my first PR, so please bear with me.