### PR TITLE
Swipe movement for trackpad

### DIFF
--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -80,14 +80,8 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
 
 
     if(this.startingAxisData.length > 0){
-      var movingLeft     = this.startingAxisData[0] > 0 && axis_data[0] < 0
-      var movingRight    = this.startingAxisData[0] < 0 && axis_data[0] > 0
-      var movingForward  = this.startingAxisData[1] > 0 && axis_data[1] < 0
-      var movingBackward = this.startingAxisData[1] < 0 && axis_data[1] > 0
-
       var velX = axis_data[0] < this.startingAxisData[0] ? -1 : 1
       var velZ = axis_data[1] < this.startingAxisData[1] ? 1 : -1
-
 
       var absChangeZ = Math.abs(this.startingAxisData[1] - axis_data[1])
       var absChangeX = Math.abs(this.startingAxisData[0] - axis_data[0])

--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -134,19 +134,19 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
       let velX = 0;
       let velZ = 0;
 
-      if(this.data.enableNegX && ( axisData[0] < this.startingAxisData[0] )) {
+      if(this.data.enableNegX == true && ( axisData[0] < this.startingAxisData[0] )) {
         velX = -1;
       }
 
-      if(this.data.enablePosX && ( axisData[0] > this.startingAxisData[0] )) {
+      if(this.data.enablePosX == true && ( axisData[0] > this.startingAxisData[0] )) {
         velX = 1;
       }
 
-      if(this.data.enableNegZ && ( axisData[1] > this.startingAxisData[1] )) {
+      if(this.data.enableNegZ == true && ( axisData[1] > this.startingAxisData[1] )) {
         velZ = -1;
       }
 
-      if(this.data.enableNegZ && ( axisData[1] < this.startingAxisData[1] )) {
+      if(this.data.enableNegZ == true && ( axisData[1] < this.startingAxisData[1] )) {
         velZ = 1;
       }
 
@@ -170,19 +170,19 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
     let velX = 0;
     let velZ = 0;
 
-    if(this.data.enableNegX && ( axisData[0] < 0 )) {
+    if(this.data.enableNegX == true && ( axisData[0] < 0 )) {
       velX = -1;
     }
 
-    if(this.data.enablePosX && ( axisData[0] > 0 )) {
+    if(this.data.enablePosX == true && ( axisData[0] > 0 )) {
       velX = 1;
     }
 
-    if(this.data.enableNegZ && ( axisData[1] > 0 )) {
+    if(this.data.enableNegZ == true && ( axisData[1] > 0 )) {
       velZ = -1;
     }
 
-    if(this.data.enableNegZ && ( axisData[1] < 0 )) {
+    if(this.data.enableNegZ == true && ( axisData[1] < 0 )) {
       velZ = 1;
     }
 

--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -61,7 +61,6 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
 
   onTouchStart: function (e) {
     this.startingAxisData = [];
-    this.canRecordAxis = true;
     e.preventDefault();
   },
 

--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -33,35 +33,35 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
   },
 
   addEventListeners: function () {
-    const targetEl = this.el;
+    const sceneEl = this.el.sceneEl;
 
-    targetEl.addEventListener('axismove', this.onAxisMove);
+    sceneEl.addEventListener('axismove', this.onAxisMove);
 
     if(this.data.mode == 'swipe' || this.data.mode == 'touch') {
-      targetEl.addEventListener('trackpadtouchstart', this.onTouchStart);
-      targetEl.addEventListener('trackpadtouchend', this.onTouchEnd);
+      sceneEl.addEventListener('trackpadtouchstart', this.onTouchStart);
+      sceneEl.addEventListener('trackpadtouchend', this.onTouchEnd);
     }
 
     if(this.data.mode == 'press') {
-      targetEl.addEventListener('trackpaddown', this.onTouchStart);
-      targetEl.addEventListener('trackpadup', this.onTouchEnd);
+      sceneEl.addEventListener('trackpaddown', this.onTouchStart);
+      sceneEl.addEventListener('trackpadup', this.onTouchEnd);
     }
 
   },
 
   removeEventListeners: function () {
-    const targetEl = this.el;
+    const sceneEl = this.el.sceneEl;
 
-    targetEl.removeEventListener('axismove', this.onAxisMove);
+    sceneEl.removeEventListener('axismove', this.onAxisMove);
 
     if(this.data.mode == 'swipe' || this.data.mode == 'touch') {
-      targetEl.removeEventListener('trackpadtouchstart', this.onTouchStart);
-      targetEl.removeEventListener('trackpadtouchend', this.onTouchEnd);
+      sceneEl.removeEventListener('trackpadtouchstart', this.onTouchStart);
+      sceneEl.removeEventListener('trackpadtouchend', this.onTouchEnd);
     }
 
     if(this.data.mode == 'press') {
-      targetEl.removeEventListener('trackpaddown', this.onTouchStart);
-      targetEl.removeEventListener('trackpadup', this.onTouchEnd);
+      sceneEl.removeEventListener('trackpaddown', this.onTouchStart);
+      sceneEl.removeEventListener('trackpadup', this.onTouchEnd);
     }
 
   },

--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -8,7 +8,7 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
     enablePosX: { default: true },
     enableNegZ: { default: true },
     enablePosZ: { default: true },
-    mode: { type: 'string', default: 'swipe', oneOf: ['swipe', 'touch', 'press'] }
+    mode: { type: 'string', default: 'touch', oneOf: ['swipe', 'touch', 'press'] }
 
   },
 

--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -126,7 +126,6 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
       this.canRecordAxis = false;
       this.startingAxisData[0] = axisData[0];
       this.startingAxisData[1] = axisData[1];
-      this.isMoving = true;
     }
 
 
@@ -142,7 +141,7 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
         velX = 1;
       }
 
-      if(this.data.enableNegZ == true && ( axisData[1] > this.startingAxisData[1] )) {
+      if(this.data.enablePosZ == true && ( axisData[1] > this.startingAxisData[1] )) {
         velZ = -1;
       }
 
@@ -150,15 +149,17 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
         velZ = 1;
       }
 
-      const absChangeZ = Math.abs(this.startingAxisData[1] - axisData[1]);
-      const absChangeX = Math.abs(this.startingAxisData[0] - axisData[0]);
+      const absChangeZ  = Math.abs(this.startingAxisData[1] - axisData[1]);
+      const absChangeX  = Math.abs(this.startingAxisData[0] - axisData[0]);
 
       if(absChangeX > absChangeZ)  {
         this.zVel = 0;
         this.xVel = velX;
+        this.isMoving = true;
       }else{
         this.xVel = 0;
         this.zVel = velZ;
+        this.isMoving = true;
       }
 
     }
@@ -178,7 +179,7 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
       velX = 1;
     }
 
-    if(this.data.enableNegZ == true && ( axisData[1] > 0 )) {
+    if(this.data.enablePosZ == true && ( axisData[1] > 0 )) {
       velZ = -1;
     }
 

--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -4,7 +4,10 @@
 module.exports = AFRAME.registerComponent('trackpad-controls', {
   schema: {
     enabled: { default: true },
-    allowStrafe: { default: true },
+    enableNegX: { default: true },
+    enablePosX: { default: true },
+    enableNegZ: { default: true },
+    enablePosZ: { default: true },
     mode: { type: 'string', default: 'swipe', oneOf: ['swipe', 'touch', 'press'] }
 
   },
@@ -128,13 +131,29 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
 
 
     if(this.startingAxisData.length > 0){
-      const velX = axisData[0] < this.startingAxisData[0] ? -1 : 1;
-      const velZ = axisData[1] < this.startingAxisData[1] ? 1 : -1;
+      let velX = 0;
+      let velZ = 0;
+
+      if(this.data.enableNegX && ( axisData[0] < this.startingAxisData[0] )) {
+        velX = -1;
+      }
+
+      if(this.data.enablePosX && ( axisData[0] > this.startingAxisData[0] )) {
+        velX = 1;
+      }
+
+      if(this.data.enableNegZ && ( axisData[1] > this.startingAxisData[1] )) {
+        velZ = -1;
+      }
+
+      if(this.data.enableNegZ && ( axisData[1] < this.startingAxisData[1] )) {
+        velZ = 1;
+      }
 
       const absChangeZ = Math.abs(this.startingAxisData[1] - axisData[1]);
       const absChangeX = Math.abs(this.startingAxisData[0] - axisData[0]);
 
-      if((absChangeX > absChangeZ) && this.data.allowStrafe == true) {
+      if(absChangeX > absChangeZ)  {
         this.zVel = 0;
         this.xVel = velX;
       }else{
@@ -148,10 +167,26 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
   handleTouchAxis: function(e) {
     var axisData = e.detail.axis;
 
-    const velX = axisData[0] < 0 ? -1 : 1;
-    const velZ = axisData[1] < 0 ? 1 : -1;
+    let velX = 0;
+    let velZ = 0;
 
-    if(Math.abs(axisData[0]) > Math.abs(axisData[1]) && this.data.allowStrafe) {
+    if(this.data.enableNegX && ( axisData[0] < 0 )) {
+      velX = -1;
+    }
+
+    if(this.data.enablePosX && ( axisData[0] > 0 )) {
+      velX = 1;
+    }
+
+    if(this.data.enableNegZ && ( axisData[1] > 0 )) {
+      velZ = -1;
+    }
+
+    if(this.data.enableNegZ && ( axisData[1] < 0 )) {
+      velZ = 1;
+    }
+
+    if(Math.abs(axisData[0]) > Math.abs(axisData[1])) {
       this.zVel = 0;
       this.xVel = velX;
     }else{

--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -49,6 +49,7 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
 
   getVelocityDelta: function () {
     this.dVelocity.z = this.isMoving ? -this.zVel : 1;
+    this.dVelocity.x = this.isMoving ? this.xVel : 1;
     return this.dVelocity.clone();
   },
 
@@ -59,11 +60,13 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
   },
 
   onTouchStart: function (e) {
-    this.isMoving = true;
+    this.startingAxisData = [];
+    this.canRecordAxis = true;
     e.preventDefault();
   },
 
   onTouchEnd: function (e) {
+    this.startingAxisData = [];
     this.isMoving = false;
     e.preventDefault();
   },
@@ -71,14 +74,36 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
   onAxisMove: function(e){
     var axis_data = e.detail.axis;
 
-    if(axis_data[1] < 0){
-      this.zVel = 1;
+    if(this.startingAxisData.length === 0){
+      this.startingAxisData[0] = axis_data[0]
+      this.startingAxisData[1] = axis_data[1]
     }
 
-    if(axis_data[1] > 0){
-      this.zVel = -1;
-    }
 
+    if(this.startingAxisData.length > 0){
+      var movingLeft     = this.startingAxisData[0] > 0 && axis_data[0] < 0
+      var movingRight    = this.startingAxisData[0] < 0 && axis_data[0] > 0
+      var movingForward  = this.startingAxisData[1] > 0 && axis_data[1] < 0
+      var movingBackward = this.startingAxisData[1] < 0 && axis_data[1] > 0
+
+      var velX = axis_data[0] < this.startingAxisData[0] ? -1 : 1
+      var velZ = axis_data[1] < this.startingAxisData[1] ? 1 : -1
+
+
+      var absChangeZ = Math.abs(this.startingAxisData[1] - axis_data[1])
+      var absChangeX = Math.abs(this.startingAxisData[0] - axis_data[0])
+
+      if(absChangeZ > absChangeX) {
+        this.xVel = 0;
+        this.zVel = velZ;
+        this.isMoving = true;
+
+      }else{
+        this.zVel = 0;
+        this.xVel = velX
+        this.isMoving = true;
+      }
+    }
   }
-
 });
+

--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -60,6 +60,7 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
   },
 
   onTouchStart: function (e) {
+    this.canRecordAxis = true;
     this.startingAxisData = [];
     e.preventDefault();
   },
@@ -73,29 +74,30 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
   onAxisMove: function(e){
     var axis_data = e.detail.axis;
 
-    if(this.startingAxisData.length === 0){
-      this.startingAxisData[0] = axis_data[0]
-      this.startingAxisData[1] = axis_data[1]
+    if(this.startingAxisData.length === 0 && this.canRecordAxis){
+      this.canRecordAxis = false;
+      this.startingAxisData[0] = axis_data[0];
+      this.startingAxisData[1] = axis_data[1];
+      this.isMoving = true;
     }
 
 
     if(this.startingAxisData.length > 0){
-      var velX = axis_data[0] < this.startingAxisData[0] ? -1 : 1
-      var velZ = axis_data[1] < this.startingAxisData[1] ? 1 : -1
+      const velX = axis_data[0] < this.startingAxisData[0] ? -1 : 1;
+      const velZ = axis_data[1] < this.startingAxisData[1] ? 1 : -1;
 
-      var absChangeZ = Math.abs(this.startingAxisData[1] - axis_data[1])
-      var absChangeX = Math.abs(this.startingAxisData[0] - axis_data[0])
+      const absChangeZ = Math.abs(this.startingAxisData[1] - axis_data[1]);
+      const absChangeX = Math.abs(this.startingAxisData[0] - axis_data[0]);
 
       if(absChangeZ > absChangeX) {
         this.xVel = 0;
         this.zVel = velZ;
-        this.isMoving = true;
 
       }else{
         this.zVel = 0;
-        this.xVel = velX
-        this.isMoving = true;
+        this.xVel = velX;
       }
+
     }
   }
 });

--- a/src/controls/trackpad-controls.js
+++ b/src/controls/trackpad-controls.js
@@ -33,35 +33,35 @@ module.exports = AFRAME.registerComponent('trackpad-controls', {
   },
 
   addEventListeners: function () {
-    const sceneEl = this.el.sceneEl;
+    const targetEl = this.el;
 
-    sceneEl.addEventListener('axismove', this.onAxisMove);
+    targetEl.addEventListener('axismove', this.onAxisMove);
 
     if(this.data.mode == 'swipe' || this.data.mode == 'touch') {
-      sceneEl.addEventListener('trackpadtouchstart', this.onTouchStart);
-      sceneEl.addEventListener('trackpadtouchend', this.onTouchEnd);
+      targetEl.addEventListener('trackpadtouchstart', this.onTouchStart);
+      targetEl.addEventListener('trackpadtouchend', this.onTouchEnd);
     }
 
     if(this.data.mode == 'press') {
-      sceneEl.addEventListener('trackpaddown', this.onTouchStart);
-      sceneEl.addEventListener('trackpadup', this.onTouchEnd);
+      targetEl.addEventListener('trackpaddown', this.onTouchStart);
+      targetEl.addEventListener('trackpadup', this.onTouchEnd);
     }
 
   },
 
   removeEventListeners: function () {
-    const sceneEl = this.el.sceneEl;
+    const targetEl = this.el;
 
-    sceneEl.removeEventListener('axismove', this.onAxisMove);
+    targetEl.removeEventListener('axismove', this.onAxisMove);
 
     if(this.data.mode == 'swipe' || this.data.mode == 'touch') {
-      sceneEl.removeEventListener('trackpadtouchstart', this.onTouchStart);
-      sceneEl.removeEventListener('trackpadtouchend', this.onTouchEnd);
+      targetEl.removeEventListener('trackpadtouchstart', this.onTouchStart);
+      targetEl.removeEventListener('trackpadtouchend', this.onTouchEnd);
     }
 
     if(this.data.mode == 'press') {
-      sceneEl.removeEventListener('trackpaddown', this.onTouchStart);
-      sceneEl.removeEventListener('trackpadup', this.onTouchEnd);
+      targetEl.removeEventListener('trackpaddown', this.onTouchStart);
+      targetEl.removeEventListener('trackpadup', this.onTouchEnd);
     }
 
   },


### PR DESCRIPTION
New PR for adding swipe-based movement to trackpad-controls. The default is still touch, and there are a handful of new options for controlling movement via trackpad.