### PR TITLE
[movement-controls] Fixes attaching to wrong camera when there is more than one in the scene

### DIFF
--- a/src/controls/movement-controls.js
+++ b/src/controls/movement-controls.js
@@ -22,7 +22,7 @@ module.exports = AFRAME.registerComponent('movement-controls', {
     speed:              { default: 0.3, min: 0 },
     fly:                { default: false },
     constrainToNavMesh: { default: false },
-    camera:             { default: '[camera]', type: 'selector' }
+    camera:             { default: '[movement-controls] [camera]', type: 'selector' }
   },
 
   /*******************************************************************


### PR DESCRIPTION
Fixes #287 by ensuring the camera found is an element within the movement-controls element.