### PR TITLE
fix: add https to broken cdn src url

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ src
 In the [dist/](https://github.com/donmccurdy/aframe-extras/tree/master/dist) folder, download any package(s) you need. Include the scripts on your page, and all components are automatically registered for you:
 
 ```html
-<script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v6.0.0/dist/aframe-extras.min.js"></script>
+<script src="https://cdn.rawgit.com/donmccurdy/aframe-extras/v6.0.0/dist/aframe-extras.min.js"></script>
 ```
 
 CDN builds for aframe-extras/v6.0.0:


### PR DESCRIPTION
Cdn src url of documentation was missing 'https'.