### PR TITLE
ray.direction.z set to 0

### DIFF
--- a/src/pathfinding/nav-agent.js
+++ b/src/pathfinding/nav-agent.js
@@ -86,7 +86,7 @@ module.exports = AFRAME.registerComponent('nav-agent', {
       // ground, not traveling in a straight line from higher to lower waypoints.
       raycaster.ray.origin.copy(vNext);
       raycaster.ray.origin.y += 1.5;
-      raycaster.ray.direction.y = -1;
+      raycaster.ray.direction = {x:0, y:-1, z:0};
       const intersections = raycaster.intersectObject(this.system.getNavMesh());
 
       if (!intersections.length) {


### PR DESCRIPTION
Navmesh does not work with current A-Frame.

raycaster.ray.direction.z defaults to -1 in newer Versions of A-Frame. So I set it to 0 explicitly.