### PR TITLE
fixing issue #340

### DIFF
--- a/src/controls/movement-controls.js
+++ b/src/controls/movement-controls.js
@@ -31,7 +31,9 @@ module.exports = AFRAME.registerComponent('movement-controls', {
 
   init: function () {
     const el = this.el;
-
+    if (!this.data.camera) {
+      this.data.camera = el.querySelector('[camera]')
+    }
     this.velocityCtrl = null;
 
     this.velocity = new THREE.Vector3();


### PR DESCRIPTION
see: https://github.com/n5ro/aframe-extras/issues/340

not sure if the code style is clean enough for you. this attempts to be as 'light' as possible and only catch a fail scenario, but make sure not to change behavior of code that doesn't currently throw an error. However, one could just as well remove the 'default' selector from the schema and just explicitly always assign within `init()` for greater clarity and fewer potential code paths--I can't myself imagine a case where they would produce diverging results, but I don't pretend to have the full insight into every use case of this library.