### PR TITLE
Allow to specify a node name to look for as navmesh

### DIFF
--- a/src/pathfinding/nav-mesh.js
+++ b/src/pathfinding/nav-mesh.js
@@ -5,9 +5,14 @@
  * nav mesh in the pathfinding system.
  */
 module.exports = AFRAME.registerComponent('nav-mesh', {
+  schema: {
+    nodeName: {type: 'string'}
+  },
+
   init: function () {
     this.system = this.el.sceneEl.systems.nav;
     this.hasLoadedNavMesh = false;
+    this.nodeName = this.data.nodeName;
     this.el.addEventListener('object3dset', this.loadNavMesh.bind(this));
   },
 
@@ -16,6 +21,7 @@ module.exports = AFRAME.registerComponent('nav-mesh', {
   },
 
   loadNavMesh: function () {
+    var self = this;
     const object = this.el.getObject3D('mesh');
     const scene = this.el.sceneEl.object3D;
 
@@ -23,7 +29,8 @@ module.exports = AFRAME.registerComponent('nav-mesh', {
 
     let navMesh;
     object.traverse((node) => {
-      if (node.isMesh) navMesh = node;
+      if (node.isMesh &&
+          (!self.nodeName || node.name === self.nodeName)) navMesh = node;
     });
 
     if (!navMesh) return;


### PR DESCRIPTION
This is useful for models that already embed a navmesh, as we can just use them as they are and not e.g. extract the navmesh in a separate file.

Example usage:

`<a-entity
        gltf-model="a-scene-with-embedded-navmesh.glb"
        position="0 0 0"
        nav-mesh="nodeName: navMesh"></a-entity>`