### PR TITLE
Fix navmeshes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "aframe": "*"
   },
   "dependencies": {
-    "three-pathfinding": "^0.7.0"
+    "three-pathfinding": "^0.14.0"
   },
   "devDependencies": {
     "aframe": "^0.8.2",

--- a/src/pathfinding/nav-mesh.js
+++ b/src/pathfinding/nav-mesh.js
@@ -4,7 +4,7 @@
  * Waits for a mesh to be loaded on the current entity, then sets it as the
  * nav mesh in the pathfinding system.
  */
-module.exports = AFRAME.registerComponent('nav-mesh', {
+ module.exports = AFRAME.registerComponent('nav-mesh', {
   schema: {
     nodeName: {type: 'string'}
   },
@@ -35,14 +35,8 @@ module.exports = AFRAME.registerComponent('nav-mesh', {
 
     if (!navMesh) return;
 
-    const navMeshGeometry = navMesh.geometry.isBufferGeometry
-      ? new THREE.Geometry().fromBufferGeometry(navMesh.geometry)
-      : navMesh.geometry.clone();
-
     scene.updateMatrixWorld();
-    navMeshGeometry.applyMatrix(navMesh.matrixWorld);
-    this.system.setNavMeshGeometry(navMeshGeometry);
-
+    this.system.setNavMeshGeometry(navMesh.geometry);
     this.hasLoadedNavMesh = true;
   }
 });


### PR DESCRIPTION
I've updated the three-pathfinding library from 0.7 to 0.14, which now has support for BufferGeometry. 

In nav-mesh.js I'm passing in a BufferGeometry object directly. Tested this on my own application and it seems to be working about as expected. Please try for yourself!