### PR TITLE
Fix WebXR handedness search for gamepad-controls

### DIFF
--- a/src/controls/gamepad-controls.js
+++ b/src/controls/gamepad-controls.js
@@ -251,7 +251,7 @@ module.exports = AFRAME.registerComponent('gamepad-controls', {
         const xrController = this.system.controllers[i];
         const xrGamepad = xrController ? xrController.gamepad : null;
         _xrGamepads.push(xrGamepad);
-        if (xrGamepad && xrGamepad.handedness === handPreference) return xrGamepad;
+        if (xrGamepad && xrController.handedness === handPreference) return xrGamepad;
       }
 
       // https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/hand


### PR DESCRIPTION
At least in the current version of the WebXR spec, `handedness` is a property of XRInputSource (`xrController`), rather than Gamepad.

This leads to an issue discussed on the WebXR Discord chat (https://discord.com/channels/758943204715659264/759166287901098024/856977980219981844) where the controls attach to the wrong hand, even when the correct hand shows up later.