### PR TITLE
Fix animation not always playing because of setTime executed after play

### DIFF
--- a/src/loaders/animation-mixer.js
+++ b/src/loaders/animation-mixer.js
@@ -118,12 +118,12 @@ module.exports = AFRAME.registerComponent('animation-mixer', {
         action.clampWhenFinished = data.clampWhenFinished;
         if (data.duration) action.setDuration(data.duration);
         if (data.timeScale !== 1) action.setEffectiveTimeScale(data.timeScale);
+        this.mixer.setTime(data.startFrame / 1000);
         action
           .setLoop(LoopMode[data.loop], data.repetitions)
           .fadeIn(data.crossFadeDuration)
           .play();
         this.activeActions.push(action);
-        this.mixer.setTime(data.startFrame / 1000);
       }
     }
   },


### PR DESCRIPTION
Since the changes in #337 my animation doesn't always play when I set a new animation.
This change fixes the issue for me.
I also commented on https://github.com/n5ro/aframe-extras/pull/337#issuecomment-915407558
@netgfx @hiliang-cmu Can you verify this works for you?