### PR TITLE
threejs r141 compatibility for movement-controls

### DIFF
--- a/lib/ColladaLoader.js
+++ b/lib/ColladaLoader.js
@@ -2751,7 +2751,7 @@ THREE.ColladaLoader.prototype = {
         case 'rotate':
           data.obj = new THREE.Vector3();
           data.obj.fromArray( array );
-          data.angle = THREE.Math.degToRad( array[ 3 ] );
+          data.angle = THREE.MathUtils.degToRad( array[ 3 ] );
           break;
 
       }
@@ -3023,7 +3023,7 @@ THREE.ColladaLoader.prototype = {
                   switch ( joint.type ) {
 
                     case 'revolute':
-                      matrix.multiply( m0.makeRotationAxis( axis, THREE.Math.degToRad( value ) ) );
+                      matrix.multiply( m0.makeRotationAxis( axis, THREE.MathUtils.degToRad( value ) ) );
                       break;
 
                     case 'prismatic':
@@ -3119,7 +3119,7 @@ THREE.ColladaLoader.prototype = {
           case 'rotate':
             var array = parseFloats( child.textContent );
             var vector = new THREE.Vector3().fromArray( array );
-            var angle = THREE.Math.degToRad( array[ 3 ] );
+            var angle = THREE.MathUtils.degToRad( array[ 3 ] );
             transforms.push( {
               sid: child.getAttribute( 'sid' ),
               type: child.nodeName,
@@ -3226,7 +3226,7 @@ THREE.ColladaLoader.prototype = {
 
           case 'rotate':
             var array = parseFloats( child.textContent );
-            var angle = THREE.Math.degToRad( array[ 3 ] );
+            var angle = THREE.MathUtils.degToRad( array[ 3 ] );
             data.matrix.multiply( matrix.makeRotationAxis( vector.fromArray( array ), angle ) );
             data.transforms[ child.getAttribute( 'sid' ) ] = child.nodeName;
             break;

--- a/lib/FBXLoader.js
+++ b/lib/FBXLoader.js
@@ -1109,7 +1109,7 @@ module.exports = THREE.FBXLoader = ( function () {
 
 						if ( lightAttribute.InnerAngle !== undefined ) {
 
-							angle = THREE.Math.degToRad( lightAttribute.InnerAngle.value );
+							angle = THREE.MathUtils.degToRad( lightAttribute.InnerAngle.value );
 
 						}
 
@@ -1119,7 +1119,7 @@ module.exports = THREE.FBXLoader = ( function () {
 						// TODO: this is not correct - FBX calculates outer and inner angle in degrees
 						// with OuterAngle > InnerAngle && OuterAngle <= Math.PI
 						// while three.js uses a penumbra between (0, 1) to attenuate the inner angle
-							penumbra = THREE.Math.degToRad( lightAttribute.OuterAngle.value );
+							penumbra = THREE.MathUtils.degToRad( lightAttribute.OuterAngle.value );
 							penumbra = Math.max( penumbra, 1 );
 
 						}
@@ -2631,19 +2631,19 @@ module.exports = THREE.FBXLoader = ( function () {
 			if ( curves.x !== undefined ) {
 
 				this.interpolateRotations( curves.x );
-				curves.x.values = curves.x.values.map( THREE.Math.degToRad );
+				curves.x.values = curves.x.values.map( THREE.MathUtils.degToRad );
 
 			}
 			if ( curves.y !== undefined ) {
 
 				this.interpolateRotations( curves.y );
-				curves.y.values = curves.y.values.map( THREE.Math.degToRad );
+				curves.y.values = curves.y.values.map( THREE.MathUtils.degToRad );
 
 			}
 			if ( curves.z !== undefined ) {
 
 				this.interpolateRotations( curves.z );
-				curves.z.values = curves.z.values.map( THREE.Math.degToRad );
+				curves.z.values = curves.z.values.map( THREE.MathUtils.degToRad );
 
 			}
 
@@ -2652,7 +2652,7 @@ module.exports = THREE.FBXLoader = ( function () {
 
 			if ( preRotations !== undefined ) {
 
-				preRotations = preRotations.map( THREE.Math.degToRad );
+				preRotations = preRotations.map( THREE.MathUtils.degToRad );
 				preRotations.push( 'ZYX' );
 
 				preRotations = new THREE.Euler().fromArray( preRotations );
@@ -2662,7 +2662,7 @@ module.exports = THREE.FBXLoader = ( function () {
 
 			if ( postRotations !== undefined ) {
 
-				postRotations = postRotations.map( THREE.Math.degToRad );
+				postRotations = postRotations.map( THREE.MathUtils.degToRad );
 				postRotations.push( 'ZYX' );
 
 				postRotations = new THREE.Euler().fromArray( postRotations );
@@ -3896,7 +3896,7 @@ module.exports = THREE.FBXLoader = ( function () {
 
 		if ( transformData.rotation ) {
 
-			var array = transformData.rotation.map( THREE.Math.degToRad );
+			var array = transformData.rotation.map( THREE.MathUtils.degToRad );
 			array.push( order );
 			rotation.makeRotationFromEuler( tempEuler.fromArray( array ) );
 
@@ -3904,7 +3904,7 @@ module.exports = THREE.FBXLoader = ( function () {
 
 		if ( transformData.preRotation ) {
 
-			var array = transformData.preRotation.map( THREE.Math.degToRad );
+			var array = transformData.preRotation.map( THREE.MathUtils.degToRad );
 			array.push( order );
 			tempMat.makeRotationFromEuler( tempEuler.fromArray( array ) );
 
@@ -3914,7 +3914,7 @@ module.exports = THREE.FBXLoader = ( function () {
 
 		if ( transformData.postRotation ) {
 
-			var array = transformData.postRotation.map( THREE.Math.degToRad );
+			var array = transformData.postRotation.map( THREE.MathUtils.degToRad );
 			array.push( order );
 			tempMat.makeRotationFromEuler( tempEuler.fromArray( array ) );
 

--- a/src/controls/gamepad-controls.js
+++ b/src/controls/gamepad-controls.js
@@ -65,10 +65,10 @@ module.exports = AFRAME.registerComponent('gamepad-controls', {
     // Rotation
     const rotation = this.el.object3D.rotation;
     this.pitch = new THREE.Object3D();
-    this.pitch.rotation.x = THREE.Math.degToRad(rotation.x);
+    this.pitch.rotation.x = THREE.MathUtils.degToRad(rotation.x);
     this.yaw = new THREE.Object3D();
     this.yaw.position.y = 10;
-    this.yaw.rotation.y = THREE.Math.degToRad(rotation.y);
+    this.yaw.rotation.y = THREE.MathUtils.degToRad(rotation.y);
     this.yaw.add(this.pitch);
 
     this._lookVector = new THREE.Vector2();


### PR DESCRIPTION
Replace `THREE.Math.degToRad` by `THREE.MathUtils.degToRad` for threejs r141 compatibility (aframe master). Note that this change is still compatible with threejs r125 aframe 1.2.0.
cc @AdaRoseCannon because you use the movement-controls component in aframe-xr-boilerplate.

I also changed it in `lib/ColladaLoader.js` and in `lib/FBXLoader.js` but at one point it may be good to recopy the loaders from `three/examples/js/loaders/ColladaLoader.js` and `three/examples/js/loaders/FBXLoader.js`. There are maybe some fixes since then, but I don't know it's hard to compare the files.

I didn't test all the components of this repository for threejs r141 compatibility, I fixed just the error I saw in the console with movement-controls component included in a project.

