### PR TITLE
fix for y velocity persisting after fly toggled off

### DIFF
--- a/src/controls/movement-controls.js
+++ b/src/controls/movement-controls.js
@@ -201,6 +201,7 @@ module.exports = AFRAME.registerComponent('movement-controls', {
           vector2.set(dVelocity.x, dVelocity.z);
           vector2.setLength(factor * this.data.speed * 16.66667);
           velocity.x = vector2.x;
+          velocity.y = 0;
           velocity.z = vector2.y;
         }
       }


### PR DESCRIPTION
When fly mode is active and a user begins to travel, a velocity is (potentially) set on the y-axis. When fly mode is de-activated, the velocity calculation ignores the y-axis, causing the velocity to carry over from when the user was in fly mode.

To reproduce:
- with fly mode active, move up/down
- disable fly mode (via setAttribute or otherwise)
- move forwards

Expected Results:
- the user y-position does not change while moving forwards once fly mode has been de-activated

Actual Results:
- the user's y-position continues along the same line as when fly mode was de-activated, giving a flying effect when fly mode has been disabled

This change explicitly sets y-axis velocity to 0 when not flying, fixing the issue. Fixes #305.