### PR TITLE
Reintroduce the applyMatrix for navmesh geometry

### DIFF
--- a/examples/castle/index.html
+++ b/examples/castle/index.html
@@ -69,7 +69,7 @@ AFRAME.registerComponent('not-mobile',  {
       <a-entity id="rig"
                 movement-controls="constrainToNavMesh: true;
                                    controls: checkpoint, gamepad, trackpad, keyboard, touch;"
-                position="-7 0 1">
+                position="-7 0 21">
         <a-entity camera
                   position="0 1.6 0"
                   look-controls="pointerLockEnabled: true">
@@ -101,10 +101,11 @@ AFRAME.registerComponent('not-mobile',  {
       <a-entity nav-mesh
                 normal-material
                 visible="false"
+                position="0 0 20"
                 gltf-model="#navmesh"></a-entity>
 
       <!-- Scene. -->
-      <a-entity position="0 0 0"
+      <a-entity position="0 0 20"
                 scale="3 3 3"
                 gltf-model="#castle">
       </a-entity>

--- a/src/pathfinding/nav-mesh.js
+++ b/src/pathfinding/nav-mesh.js
@@ -4,7 +4,7 @@
  * Waits for a mesh to be loaded on the current entity, then sets it as the
  * nav mesh in the pathfinding system.
  */
- module.exports = AFRAME.registerComponent('nav-mesh', {
+module.exports = AFRAME.registerComponent('nav-mesh', {
   schema: {
     nodeName: {type: 'string'}
   },
@@ -35,8 +35,10 @@
 
     if (!navMesh) return;
 
+    const navMeshGeometry = navMesh.geometry.clone();
     scene.updateMatrixWorld();
-    this.system.setNavMeshGeometry(navMesh.geometry);
+    navMeshGeometry.applyMatrix4(navMesh.matrixWorld);
+    this.system.setNavMeshGeometry(navMeshGeometry);
     this.hasLoadedNavMesh = true;
   }
 });


### PR DESCRIPTION
Reintroduce the applyMatrix for navmesh geometry to take into account position and scale on the entity.
This fixes regression introduced in #358 
This closes #369, see comments starting at https://github.com/n5ro/aframe-extras/issues/369#issuecomment-1336387766