### PR TITLE
Add nipple-controls to have virtual joysticks on touch devices

### DIFF
--- a/examples/castle/index.html
+++ b/examples/castle/index.html
@@ -68,7 +68,7 @@ AFRAME.registerComponent('not-mobile',  {
       <!-- Player. -->
       <a-entity id="rig"
                 movement-controls="constrainToNavMesh: true;
-                                   controls: checkpoint, gamepad, trackpad, keyboard, touch;"
+                                   controls: checkpoint, gamepad, trackpad, keyboard, nipple;"
                 position="-7 0 21">
         <a-entity camera
                   position="0 1.6 0"

--- a/examples/index.html
+++ b/examples/index.html
@@ -69,7 +69,7 @@
           </tr>
           <tr>
             <td><a href="castle/">Castle</a></td>
-            <td>navmesh, locomotion</td>
+            <td>navmesh, locomotion, hidden virtual joysticks on touch devices</td>
             <td>✅</td>
           </tr>
           <tr>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "7.0.0",
       "license": "MIT",
       "dependencies": {
+        "nipplejs": "^0.10.1",
         "three-pathfinding": "^1.1.0"
       },
       "devDependencies": {
@@ -6921,6 +6922,11 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
+    },
+    "node_modules/nipplejs": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/nipplejs/-/nipplejs-0.10.1.tgz",
+      "integrity": "sha512-BuKBDfdd7BVK6E7sivHwrRPh9TETsHuHEwuT95nAjRz2uJu5roYngNs+BdRe8nYf8mP6OZ9aRqdgMlqVsDMRcw=="
     },
     "node_modules/node-watch": {
       "version": "0.3.5",
@@ -15711,6 +15717,11 @@
           "dev": true
         }
       }
+    },
+    "nipplejs": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/nipplejs/-/nipplejs-0.10.1.tgz",
+      "integrity": "sha512-BuKBDfdd7BVK6E7sivHwrRPh9TETsHuHEwuT95nAjRz2uJu5roYngNs+BdRe8nYf8mP6OZ9aRqdgMlqVsDMRcw=="
     },
     "node-watch": {
       "version": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "aframe": "*"
   },
   "dependencies": {
+    "nipplejs": "^0.10.1",
     "three-pathfinding": "^1.1.0"
   },
   "devDependencies": {

--- a/src/controls/README.md
+++ b/src/controls/README.md
@@ -8,6 +8,7 @@ Extensible movement/rotation/hotkey controls, with support for a variety of inpu
   + **gamepad-controls**: Gamepad-based rotation and movement.
   + **trackpad-controls**: Trackpad-based movement.
 - **checkpoint-controls**: Move to checkpoints created with the `checkpoint` component. *Not included by default with `movement-controls`, but may be added as shown in examples.*
+- **nipple-controls**: Virtual joysticks for rotation and movement on touch devices. This is using the [nipplejs](https://github.com/yoannmoinet/nipplejs) library.
 
 For the Cardboard button, this was tested and working on both Chrome Android and Safari iPhone with aframe 1.4.2.
 On iPhone you need `≤a-scene vr-mode-ui="cardboardModeEnabled:true">` for the VR button to show up.
@@ -41,6 +42,27 @@ With checkpoints, and other input methods disabled:
             look-controls="pointerLockEnabled: true">
   </a-entity>
 </a-entity>
+```
+
+With gamepad, keyboard and nipple controls with virtual joysticks:
+
+```html
+<a-entity id="rig"
+          movement-controls="controls: gamepad,keyboard,nipple"
+          nipple-controls="mode: static">
+  <a-entity camera
+            position="0 1.6 0"
+            look-controls="pointerLockEnabled: true">
+  </a-entity>
+</a-entity>
+```
+
+The default for `nipple-controls` is two joysticks and `dynamic` mode (joysticks hidden, not on fixed position).
+The `static` (joysticks visible, fixed position) and `semi` modes are also supported.
+If you only want the joystick for movement on the right, you can use:
+
+```html
+nipple-controls="mode: static; lookJoystickEnabled: false; moveJoystickPosition: right"
 ```
 
 With navigation mesh:

--- a/src/controls/index.js
+++ b/src/controls/index.js
@@ -4,3 +4,4 @@ require('./keyboard-controls');
 require('./touch-controls');
 require('./movement-controls');
 require('./trackpad-controls');
+require('./nipple-controls');

--- a/src/controls/nipple-controls.js
+++ b/src/controls/nipple-controls.js
@@ -1,0 +1,212 @@
+/* global AFRAME, THREE */
+import nipplejs from "nipplejs";
+
+AFRAME.registerComponent("nipple-controls", {
+  schema: {
+    enabled: { default: true },
+    mode: { default: "dynamic", oneOf: ["static", "semi", "dynamic"] },
+    rotationSensitivity: { default: 1.0 },
+    moveJoystickEnabled: { default: true },
+    lookJoystickEnabled: { default: true },
+    sideMargin: { default: "30px" },
+    bottomMargin: { default: "70px" },
+    moveJoystickPosition: { default: "left", oneOf: ["left", "right"] },
+    lookJoystickPosition: { default: "right", oneOf: ["left", "right"] },
+  },
+
+  init() {
+    this.dVelocity = new THREE.Vector3();
+    this.lookVector = new THREE.Vector2();
+    const lookControls = this.el.querySelector("[look-controls]").components["look-controls"];
+    this.pitchObject = lookControls.pitchObject;
+    this.yawObject = lookControls.yawObject;
+    this.rigRotation = this.el.object3D.rotation;
+    this.moveData = undefined;
+    this.lookData = undefined;
+    this.moving = false;
+    this.rotating = false;
+  },
+
+  update(oldData) {
+    if (
+      this.data.moveJoystickPosition !== oldData.moveJoystickPosition ||
+      this.data.sideMargin !== oldData.sideMargin ||
+      this.data.bottomMargin !== oldData.bottomMargin ||
+      this.data.mode !== oldData.mode
+    ) {
+      this.removeMoveJoystick();
+    }
+    if (
+      this.data.lookJoystickPosition !== oldData.lookJoystickPosition ||
+      this.data.sideMargin !== oldData.sideMargin ||
+      this.data.bottomMargin !== oldData.bottomMargin ||
+      this.data.mode !== oldData.mode
+    ) {
+      this.removeLookJoystick();
+    }
+    if (this.data.enabled && this.data.moveJoystickEnabled) {
+      this.createMoveJoystick();
+    } else {
+      this.removeMoveJoystick();
+    }
+    if (this.data.enabled && this.data.lookJoystickEnabled) {
+      this.createLookJoystick();
+    } else {
+      this.removeLookJoystick();
+    }
+  },
+
+  pause() {
+    this.moving = false;
+    this.rotating = false;
+  },
+
+  remove() {
+    this.removeMoveJoystick();
+    this.removeLookJoystick();
+  },
+
+  isVelocityActive() {
+    return this.data.enabled && this.moving;
+  },
+
+  getVelocityDelta() {
+    this.dVelocity.set(0, 0, 0);
+    if (this.isVelocityActive()) {
+      const force = this.moveData.force < 1 ? this.moveData.force : 1;
+      const angle = this.moveData.angle.radian;
+      const x = Math.cos(angle) * force;
+      const z = -Math.sin(angle) * force;
+      this.dVelocity.set(x, 0, z);
+    }
+    return this.dVelocity; // We don't do a clone() here, the Vector3 will be modified by the calling code but that's fine.
+  },
+
+  isRotationActive() {
+    return this.data.enabled && this.rotating;
+  },
+
+  updateRotation(dt) {
+    if (!this.isRotationActive()) return;
+
+    const force = this.lookData.force < 1 ? this.lookData.force : 1;
+    const angle = this.lookData.angle.radian;
+    const lookVector = this.lookVector;
+    lookVector.x = Math.cos(angle) * force;
+    lookVector.y = Math.sin(angle) * force;
+    lookVector.multiplyScalar((this.data.rotationSensitivity * dt) / 1000);
+
+    this.yawObject.rotation.y -= lookVector.x;
+    let x = this.pitchObject.rotation.x + lookVector.y;
+    x = Math.max(-Math.PI / 2, Math.min(Math.PI / 2, x));
+    this.pitchObject.rotation.x = x;
+  },
+
+  tick: function (t, dt) {
+    this.updateRotation(dt);
+  },
+
+  initLeftZone() {
+    const leftZone = document.createElement("div");
+    leftZone.setAttribute("id", "joystickLeftZone");
+    leftZone.setAttribute(
+      "style",
+      `position:absolute;${this.data.moveJoystickPosition}:${this.data.sideMargin};bottom:${this.data.bottomMargin};z-index:1`
+    );
+    document.body.appendChild(leftZone);
+    this.leftZone = leftZone;
+  },
+
+  initRightZone() {
+    const rightZone = document.createElement("div");
+    rightZone.setAttribute("id", "joystickRightZone");
+    rightZone.setAttribute(
+      "style",
+      `position:absolute;${this.data.lookJoystickPosition}:${this.data.sideMargin};bottom:${this.data.bottomMargin};z-index:1`
+    );
+    document.body.appendChild(rightZone);
+    this.rightZone = rightZone;
+  },
+
+  createMoveJoystick() {
+    if (this.moveJoystick) return;
+    this.initLeftZone();
+    const options = {
+      mode: this.data.mode,
+      zone: this.leftZone,
+      color: "white",
+      fadeTime: 0,
+    };
+    this.leftZone.style.width = "100px";
+    if (this.data.mode === "static") {
+      this.leftZone.style.height = "100px";
+      options.position = { left: "50%", bottom: "50%" };
+    } else {
+      this.leftZone.style.height = "400px";
+    }
+
+    this.moveJoystick = nipplejs.create(options);
+    this.moveJoystick.on("move", (evt, data) => {
+      this.moveData = data;
+      this.moving = true;
+    });
+    this.moveJoystick.on("end", (evt, data) => {
+      this.moving = false;
+    });
+  },
+
+  createLookJoystick() {
+    if (this.lookJoystick) return;
+    this.initRightZone();
+    const options = {
+      mode: this.data.mode,
+      zone: this.rightZone,
+      color: "white",
+      fadeTime: 0,
+    };
+    this.rightZone.style.width = "100px";
+    if (this.data.mode === "static") {
+      this.rightZone.style.height = "100px";
+      options.position = { left: "50%", bottom: "50%" };
+    } else {
+      this.rightZone.style.height = "400px";
+    }
+
+    this.lookJoystick = nipplejs.create(options);
+    this.lookJoystick.on("move", (evt, data) => {
+      this.lookData = data;
+      this.rotating = true;
+    });
+    this.lookJoystick.on("end", (evt, data) => {
+      this.rotating = false;
+    });
+  },
+
+  removeMoveJoystick() {
+    if (this.moveJoystick) {
+      this.moveJoystick.destroy();
+      this.moveJoystick = undefined;
+    }
+
+    this.moveData = undefined;
+
+    if (this.leftZone && this.leftZone.parentNode) {
+      this.leftZone.remove();
+      this.leftZone = undefined;
+    }
+  },
+
+  removeLookJoystick() {
+    if (this.lookJoystick) {
+      this.lookJoystick.destroy();
+      this.lookJoystick = undefined;
+    }
+
+    this.lookData = undefined;
+
+    if (this.rightZone && this.rightZone.parentNode) {
+      this.rightZone.remove();
+      this.rightZone = undefined;
+    }
+  },
+});


### PR DESCRIPTION
Add new nipple-controls to have virtual joysticks for rotation and movement on touch devices.
You can test it on the [castle example](https://c-frame.github.io/aframe-extras/examples/castle/).

This fixes #398