### PR TITLE
Move examples to 1.5.0

### DIFF
--- a/examples/animation-controls/index.html
+++ b/examples/animation-controls/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Animation  Controls</title>
     <link rel="stylesheet" href="./styles.css">
-    <script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
     <script src="../bundle.js"></script>
     <script src="./animation-controls.js"></script>
     <script src="https://unpkg.com/aframe-environment-component@1.3.3/dist/aframe-environment-component.min.js"></script>

--- a/examples/castle/index.html
+++ b/examples/castle/index.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Castle</title>
-    <script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
     <script src="../bundle.js"></script>
     <script src="https://unpkg.com/aframe-environment-component@1.3.3/dist/aframe-environment-component.min.js"></script>
     <script>

--- a/examples/checkpoints/index.html
+++ b/examples/checkpoints/index.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Checkpoints</title>
-    <script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
     <script src="../bundle.js"></script>
   </head>
   <body>

--- a/examples/checkpoints/index.html
+++ b/examples/checkpoints/index.html
@@ -20,6 +20,7 @@
                   position="0 1.6 0"
                   look-controls="pointerLockEnabled: true">
           <a-entity cursor
+                    raycaster="objects:[checkpoint]"
                     position="0 0 -1"
                     geometry="primitive: ring; radiusInner: 0.02; radiusOuter: 0.03;"
                     material="color: #CCC; shader: flat;"></a-entity>

--- a/examples/env-map/index.html
+++ b/examples/env-map/index.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Environment Map</title>
-    <script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
     <script src="../bundle.js"></script>
   </head>
   <body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -88,19 +88,9 @@
             <td>❌</td>
           </tr>
           <tr>
-            <td><a href="platforms/">Platforms</a></td>
-            <td>physics, locomotion</td>
-            <td>❌</td>
-          </tr>
-          <tr>
-            <td><a href="playground/">Playground</a></td>
-            <td>physics</td>
-            <td>❌</td>
-          </tr>
-          <tr>
-            <td><a href="walls/">Walls</a></td>
-            <td>physics, locomotion</td>
-            <td>❌</td>
+            <td><a href="tubes/">Tubes</a></td>
+            <td>a-tube</td>
+            <td>✅</td>
           </tr>
         </tbody>
       </table>

--- a/examples/island/index.html
+++ b/examples/island/index.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Island</title>
-    <script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
     <script src="../bundle.js"></script>
   </head>
   <body>

--- a/examples/tubes/index.html
+++ b/examples/tubes/index.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Tubes</title>
-    <script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
     <script src="../bundle.js"></script>
   </head>
   <body>

--- a/examples/vive/index.html
+++ b/examples/vive/index.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Tracked controls</title>
-    <script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
     <script src="../bundle.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@c-frame/aframe-physics-system@v4.2.2/dist/aframe-physics-system.min.js"></script>
   </head>


### PR DESCRIPTION
Updated all examples to 1.5.0.  Tested them and they all seem to be good.

Fixed a couple of issues spotted along the way:
- examples/index.html lists some examples that have been retired, and doesn't list new tubes example
- fixed checkpoints example to avoid raycaster warning.

Other warnings spotted but not acted upon:
- useLegacyLights warning.  Covered by A-Frame issue: https://github.com/aframevr/aframe/pull/5389
- THREE.Material: parameter 'glslVersion' has value of undefined.  Covered by: https://github.com/supermedium/aframe-environment-component/issues/96