### PR TITLE
Allow to import specific modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,13 @@ npm install --save aframe-extras
 
 ```javascript
 // index.js
-require('aframe-extras');
+import 'aframe-extras';
+// or specific packages
+import "aframe-extras/controls/index.js";
+import "aframe-extras/pathfinding/index.js";
 ```
 
-Once installed, you'll need to compile your JavaScript using something like [webpack](https://webpack.js.org).
+Once installed, you'll need to compile your JavaScript using something like [webpack](https://webpack.js.org) with three defined as external, see webpack.config.js in this repo for an example.
 
 ## Examples
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "nipplejs": "^0.10.1",
-        "three": "0.159.0",
+        "three": "^0.159.0",
         "three-pathfinding": "^1.1.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "nipplejs": "^0.10.1",
-    "three": "0.159.0",
+    "three": "^0.159.0",
     "three-pathfinding": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,14 @@
   "author": "Don McCurdy <dm@donmccurdy.com>",
   "license": "MIT",
   "main": "index.js",
+  "exports": {
+    ".": "index.js",
+    "./controls/*": "./src/controls/*",
+    "./loaders/*": "./src/loaders/*",
+    "./misc/*": "./src/misc/*",
+    "./pathfinding/*": "./src/pathfinding/*",
+    "./primitives/*": "./src/primitives/*"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/c-frame/aframe-extras.git"


### PR DESCRIPTION
In a node project with webpack correctly configured to define three as external THREE, you can import specific modules:
```js
import "aframe-extras/controls/index.js";
import "aframe-extras/pathfinding/index.js";
```