### PR TITLE
Remove array and object allocations on each tick in gamepad-controls

### DIFF
--- a/src/controls/gamepad-controls.js
+++ b/src/controls/gamepad-controls.js
@@ -193,9 +193,9 @@ module.exports = AFRAME.registerComponent('gamepad-controls', {
         this.buttons[i] = gamepad.buttons[i].pressed;
       }
 
-    } else if (Object.keys(this.buttons)) {
+    } else {
       // Reset state if controls are disabled or controller is lost.
-      this.buttons = {};
+      for (const key in this.buttons) { this.buttons[key] = false; }
     }
   },
 


### PR DESCRIPTION
Remove array (Object.keys) and object allocations on each tick in gamepad-controls when no gamepad available.