### PR TITLE
[nipple-controls] Add elements to sceneEl instead of body to fix joysticks position when canvas is not in fullscreen

### DIFF
--- a/src/controls/nipple-controls.js
+++ b/src/controls/nipple-controls.js
@@ -25,8 +25,6 @@ AFRAME.registerComponent("nipple-controls", {
     this.lookData = undefined;
     this.moving = false;
     this.rotating = false;
-
-    this.rootEl = this.data.sceneSelector ? document.getElementById(this.data.sceneSelector) : document.body;
   },
 
   update(oldData) {

--- a/src/controls/nipple-controls.js
+++ b/src/controls/nipple-controls.js
@@ -3,6 +3,7 @@ import nipplejs from "nipplejs";
 
 AFRAME.registerComponent("nipple-controls", {
   schema: {
+    sceneSelector: { default: "" },
     enabled: { default: true },
     mode: { default: "dynamic", oneOf: ["static", "semi", "dynamic"] },
     rotationSensitivity: { default: 1.0 },
@@ -25,6 +26,8 @@ AFRAME.registerComponent("nipple-controls", {
     this.lookData = undefined;
     this.moving = false;
     this.rotating = false;
+
+    this.rootEl = this.data.sceneSelector ? document.getElementById(this.data.sceneSelector) : document.body;
   },
 
   update(oldData) {
@@ -113,7 +116,7 @@ AFRAME.registerComponent("nipple-controls", {
       "style",
       `position:absolute;${this.data.moveJoystickPosition}:${this.data.sideMargin};bottom:${this.data.bottomMargin};z-index:1`
     );
-    document.body.appendChild(leftZone);
+    this.rootEl.appendChild(leftZone);
     this.leftZone = leftZone;
   },
 
@@ -124,7 +127,7 @@ AFRAME.registerComponent("nipple-controls", {
       "style",
       `position:absolute;${this.data.lookJoystickPosition}:${this.data.sideMargin};bottom:${this.data.bottomMargin};z-index:1`
     );
-    document.body.appendChild(rightZone);
+    this.rootEl.appendChild(rightZone);
     this.rightZone = rightZone;
   },
 

--- a/src/controls/nipple-controls.js
+++ b/src/controls/nipple-controls.js
@@ -3,7 +3,6 @@ import nipplejs from "nipplejs";
 
 AFRAME.registerComponent("nipple-controls", {
   schema: {
-    sceneSelector: { default: "" },
     enabled: { default: true },
     mode: { default: "dynamic", oneOf: ["static", "semi", "dynamic"] },
     rotationSensitivity: { default: 1.0 },
@@ -116,7 +115,7 @@ AFRAME.registerComponent("nipple-controls", {
       "style",
       `position:absolute;${this.data.moveJoystickPosition}:${this.data.sideMargin};bottom:${this.data.bottomMargin};z-index:1`
     );
-    this.rootEl.appendChild(leftZone);
+    this.el.sceneEl.appendChild(leftZone);
     this.leftZone = leftZone;
   },
 
@@ -127,7 +126,7 @@ AFRAME.registerComponent("nipple-controls", {
       "style",
       `position:absolute;${this.data.lookJoystickPosition}:${this.data.sideMargin};bottom:${this.data.bottomMargin};z-index:1`
     );
-    this.rootEl.appendChild(rightZone);
+    this.el.sceneEl.appendChild(rightZone);
     this.rightZone = rightZone;
   },
 


### PR DESCRIPTION
Imagine that the scene is not 100% of the screen size.

Then, adding the joysticks in `document.body`, with `position: absolute` will place them at the bottom, but not necessarily at the bottom of the scene.

For this, my proposal is to add a scene selector, so if you have a wrapper over <a-scene>, and you modify its height, you can simply make it `position: relative` too and the joysticks will be added at the bottom of the scene, correctly.